### PR TITLE
chore: update to strapi v4.13.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@strapi/plugin-i18n": "4.12.7",
-        "@strapi/plugin-users-permissions": "4.12.7",
-        "@strapi/provider-upload-aws-s3": "4.12.7",
-        "@strapi/strapi": "4.12.7",
+        "@strapi/plugin-i18n": "4.13.1",
+        "@strapi/plugin-users-permissions": "4.13.1",
+        "@strapi/provider-upload-aws-s3": "4.13.1",
+        "@strapi/strapi": "4.13.1",
         "patch-package": "^8.0.0",
         "pg": "^8.11.3",
         "pluralize": "^8.0.0",
@@ -42,11 +42,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
-      "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "dependencies": {
-        "@babel/highlight": "^7.22.10",
+        "@babel/highlight": "^7.22.13",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -126,24 +126,24 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
-      "integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.11.tgz",
+      "integrity": "sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.10",
         "@babel/generator": "^7.22.10",
         "@babel/helper-compilation-targets": "^7.22.10",
         "@babel/helper-module-transforms": "^7.22.9",
-        "@babel/helpers": "^7.22.10",
-        "@babel/parser": "^7.22.10",
+        "@babel/helpers": "^7.22.11",
+        "@babel/parser": "^7.22.11",
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.10",
-        "@babel/types": "^7.22.10",
+        "@babel/traverse": "^7.22.11",
+        "@babel/types": "^7.22.11",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
+        "json5": "^2.2.3",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -330,22 +330,22 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.10.tgz",
-      "integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.11.tgz",
+      "integrity": "sha512-vyOXC8PBWaGc5h7GMsNx68OH33cypkEDJCHvYVVgVbbxJDROYVtexSk0gK5iCF1xNjRIN2s8ai7hwkWDq5szWg==",
       "dependencies": {
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.10",
-        "@babel/types": "^7.22.10"
+        "@babel/traverse": "^7.22.11",
+        "@babel/types": "^7.22.11"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
-      "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
+      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.4.2",
@@ -420,9 +420,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
-      "integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
+      "version": "7.22.14",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
+      "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -607,9 +607,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
-      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
+      "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -643,9 +643,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
-      "integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.11.tgz",
+      "integrity": "sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==",
       "dependencies": {
         "@babel/code-frame": "^7.22.10",
         "@babel/generator": "^7.22.10",
@@ -653,8 +653,8 @@
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.10",
-        "@babel/types": "^7.22.10",
+        "@babel/parser": "^7.22.11",
+        "@babel/types": "^7.22.11",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -663,9 +663,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.10.tgz",
-      "integrity": "sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
+      "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.5",
@@ -710,9 +710,9 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.4.tgz",
-      "integrity": "sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.5.tgz",
+      "integrity": "sha512-dSi7ow2P2YgPBZflR9AJoaTHvqmeGIgkhignYMd5zK5y6DANTvxKxp6eMEpIDUJkRAaOY/TFZ4jP1ADIO/GLVA==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.4.0.tgz",
-      "integrity": "sha512-6VZ44Ysh/Zn07xrGkdtNfmHCbGSHZzFBdzWi0pbd7chAQ/iUcpLGX99NYRZTa7Ugqg4kEHCqiHhcZnH0gLIgSg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.4.1.tgz",
+      "integrity": "sha512-2Hx945qKX7FBan5/gUdTM8fsMYrNG9clIgEcPXestbLVFAUyQYFAuju/5BMNf/PwgpVaX5pvRm4+ovjbp9D9gQ==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -753,9 +753,9 @@
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.1.tgz",
-      "integrity": "sha512-4jupk4JwkeVbrN2pStY74q6OJEYqwosB4koA66nyLeVedadtX9MHI38j2vbYmnfDGurDApP3OZO46MrWalcjiQ==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.2.tgz",
+      "integrity": "sha512-WRihpqd0l9cEh9J3IZe45Yi+Z5MfTsEXnyc3V7qXHP4ZYtIYpGOn+EJ7fyLIkyAm/8S6QIr7/mMISfAadf8zCg==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -779,12 +779,12 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.16.0.tgz",
-      "integrity": "sha512-1Z2HkvkC3KR/oEZVuW9Ivmp8TWLzGEd8T8TA04TTwPvqogfkHBdYSlflytDOqmkUxM2d1ywTg7X2dU5mC+SXvg==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.17.0.tgz",
+      "integrity": "sha512-0yVhPSyKWwYDy6Xwd7aDoj8ZXtdoHwC7El4z1/JJpIimrtDR5CVGY4lvQ0r2hP11ezB+eCHexZ6Zbz6rPUe06A==",
       "dependencies": {
         "@codemirror/state": "^6.1.4",
-        "style-mod": "^4.0.0",
+        "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
     },
@@ -1296,11 +1296,11 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-      "integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
+      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
       "dependencies": {
-        "@floating-ui/dom": "^1.3.0"
+        "@floating-ui/dom": "^1.5.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2880,21 +2880,21 @@
       }
     },
     "node_modules/@strapi/admin": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-4.12.7.tgz",
-      "integrity": "sha512-eNd0s9gnP3eNMQxnkzaNJl3b2oz9IBWJ9SPAa6VrpE6k6ifKZqUFxqOk2WYChU7JfZSBaDIhmmGpU/xWO9N6KA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-4.13.1.tgz",
+      "integrity": "sha512-hZ9ExxkldkyLzLuRGgAmMIPHkmZXRWrzU4AVOYuTF2Ov1Hwq4RLAMudFe5fdNHYQM/0Cyls5Lio2DI3d8SUfrg==",
       "dependencies": {
         "@casl/ability": "^5.4.3",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
-        "@strapi/data-transfer": "4.12.7",
+        "@strapi/data-transfer": "4.13.1",
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.12.7",
+        "@strapi/helper-plugin": "4.13.1",
         "@strapi/icons": "1.9.0",
-        "@strapi/permissions": "4.12.7",
-        "@strapi/provider-audit-logs-local": "4.12.7",
-        "@strapi/typescript-utils": "4.12.7",
-        "@strapi/utils": "4.12.7",
-        "axios": "1.4.0",
+        "@strapi/permissions": "4.13.1",
+        "@strapi/provider-audit-logs-local": "4.13.1",
+        "@strapi/typescript-utils": "4.13.1",
+        "@strapi/utils": "4.13.1",
+        "axios": "1.5.0",
         "bcryptjs": "2.4.3",
         "browserslist": "^4.17.3",
         "browserslist-to-esbuild": "1.2.0",
@@ -2981,12 +2981,12 @@
       }
     },
     "node_modules/@strapi/data-transfer": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-4.12.7.tgz",
-      "integrity": "sha512-5sNBdo9RyNlWzqEjD6LT4Y7+zoUIVC9QuFcuLOZWOkBeLNKYxlQJOUWVzy7IAchAauoUsWsCtYWfQjf1+prSjg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-4.13.1.tgz",
+      "integrity": "sha512-eEZEayF5WvvxjMD0UiBYvncRws5ocdOjaDjhPBKR1Grx9UEdzMrJi79paoylAO930dIkbSpsEmmIvImWpdXWNA==",
       "dependencies": {
-        "@strapi/logger": "4.12.7",
-        "@strapi/strapi": "4.12.7",
+        "@strapi/logger": "4.13.1",
+        "@strapi/strapi": "4.13.1",
         "chalk": "4.1.2",
         "fs-extra": "10.0.0",
         "lodash": "4.17.21",
@@ -3006,11 +3006,11 @@
       }
     },
     "node_modules/@strapi/database": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-4.12.7.tgz",
-      "integrity": "sha512-xnT2V8fkoqRU49Ex6DhZDhoIXbjMVDNI/LqTJor4bynMkYj6PmPR+BCXYE6ss6Zfvklx7VFEzgqt5+OB11hHUw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-4.13.1.tgz",
+      "integrity": "sha512-9AeyONaHdaqL7/El1vyM3cw3s3brt8d4aiFUIhGLCWVZMJAVxRgobo/KtUCpdFuH0jHxxWbNz/hkjVBiYPm+PA==",
       "dependencies": {
-        "@strapi/utils": "4.12.7",
+        "@strapi/utils": "4.13.1",
         "date-fns": "2.30.0",
         "debug": "4.3.4",
         "fs-extra": "10.0.0",
@@ -3052,9 +3052,9 @@
       }
     },
     "node_modules/@strapi/generate-new": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/generate-new/-/generate-new-4.12.7.tgz",
-      "integrity": "sha512-uJhLC6kQWDnAQb47njCb4Nfldq38Q5v6BkoyvBxm7Bfqr3fifkdi/0SkNvrKEZkTjHlHqJaGdMEOSo/zPrIbOA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/generate-new/-/generate-new-4.13.1.tgz",
+      "integrity": "sha512-YI7uP9HcELZAAHCslpXetoWfNW5XnCknreq5accKUm1kpQtE9gPfiUABgorx52RCLVyklJoH6/1wlBmJ0n0F4g==",
       "dependencies": {
         "@sentry/node": "6.19.7",
         "chalk": "^4.1.2",
@@ -3062,7 +3062,7 @@
         "fs-extra": "10.0.0",
         "inquirer": "8.2.5",
         "lodash": "4.17.21",
-        "node-fetch": "2.6.9",
+        "node-fetch": "2.7.0",
         "node-machine-id": "^1.1.10",
         "ora": "^5.4.1",
         "semver": "7.5.4",
@@ -3074,13 +3074,13 @@
       }
     },
     "node_modules/@strapi/generators": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-4.12.7.tgz",
-      "integrity": "sha512-FyzdEim2e+FFXdj3dnvjowm8WRbIviGMNwtuLSlJ31PjXNYE8iwOKkeQzuJeDhHvUzJQD/lI8t4x8zhJ2W7W0Q==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-4.13.1.tgz",
+      "integrity": "sha512-YzFwJ+7pyFSMKEp9iDoDjDr769QP2PEhPGrRcnztKI7bCKCAs28xz0ff0hPKvPvDpbz83+1Yu3+yLEatcNZqRQ==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/typescript-utils": "4.12.7",
-        "@strapi/utils": "4.12.7",
+        "@strapi/typescript-utils": "4.13.1",
+        "@strapi/utils": "4.13.1",
         "chalk": "4.1.2",
         "copyfiles": "2.4.1",
         "fs-extra": "10.0.0",
@@ -3094,11 +3094,11 @@
       }
     },
     "node_modules/@strapi/helper-plugin": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.12.7.tgz",
-      "integrity": "sha512-Tg7wmJc5BIrY2nLPLOEVLk6v5FdcG1YEp7hsiRmTbEgZUsbwDdmmy5eROukpKR9pSF+TFOymYFG0em3gnPN96Q==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.13.1.tgz",
+      "integrity": "sha512-qUxUuVfeeXSmTEKykqEq36Y56iwg0WfZRK1xREuiLiLWguah7LpN1WEieZbItsMK8C/S6g4QNn9j78bx5vOvrg==",
       "dependencies": {
-        "axios": "1.4.0",
+        "axios": "1.5.0",
         "date-fns": "2.30.0",
         "formik": "2.4.0",
         "immer": "9.0.19",
@@ -3133,9 +3133,9 @@
       }
     },
     "node_modules/@strapi/logger": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-4.12.7.tgz",
-      "integrity": "sha512-G882eZoq9lbZjtJIG4kmkXW0EwHLiEuat2PVJ38IV733DMrwLJcK7f9DzkrE7eW7MVaSazTH0t1uPvhUNMyxUQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-4.13.1.tgz",
+      "integrity": "sha512-JM6GX+XWSR1p6A7JU4D40MbhgXbKf49Rf2aJSIxlqZa/usGFa+DlEnzF9c+0DUw+XFj9oF+8CPebRbwRw4CmAQ==",
       "dependencies": {
         "lodash": "4.17.21",
         "winston": "3.10.0"
@@ -3146,12 +3146,12 @@
       }
     },
     "node_modules/@strapi/permissions": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-4.12.7.tgz",
-      "integrity": "sha512-mZx2QRRhocr/eifsVqmB0S2q8eq1JEgGy2rui1iLUY0+UjexMgSnGBjr9q2kXQJ50I2VRl9Qj9L1QWpRaq2cOQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-4.13.1.tgz",
+      "integrity": "sha512-yPL0/4gFrCkSbW1wB8EblWVGK1rU5+BFFoyEfLNoV91vq+ZE6LsVYaGP4mjtdAy6QaEfT5CD/9F3RsL2H7KKYg==",
       "dependencies": {
         "@casl/ability": "5.4.4",
-        "@strapi/utils": "4.12.7",
+        "@strapi/utils": "4.13.1",
         "lodash": "4.17.21",
         "sift": "16.0.1"
       },
@@ -3161,13 +3161,14 @@
       }
     },
     "node_modules/@strapi/plugin-content-manager": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-manager/-/plugin-content-manager-4.12.7.tgz",
-      "integrity": "sha512-/jWgAT5kCy+3PNrZcORj81DUd6lRzQ0YWhwjmEx3ZWYBkdnYdW6pdbbT8JGS/hUqmdpk1lkMoE1sOtWRbGUCIw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-manager/-/plugin-content-manager-4.13.1.tgz",
+      "integrity": "sha512-A11YCpsgnfNp4qqVaSGLhpe3ayKwmTpxfU1+FU3xNy2FJiP/26l17hJ2Dmn1PC/w6AIS+6LC+rZtURzpF2Yz+g==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/utils": "4.12.7",
-        "lodash": "4.17.21"
+        "@strapi/utils": "4.13.1",
+        "lodash": "4.17.21",
+        "qs": "6.11.1"
       },
       "engines": {
         "node": ">=16.0.0 <=20.x.x",
@@ -3175,16 +3176,16 @@
       }
     },
     "node_modules/@strapi/plugin-content-type-builder": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.12.7.tgz",
-      "integrity": "sha512-KYmAW9yqIpLN0N0cCQ6gKz5/wddSbpaQ8F1v/kW415vKKjehVni5za5CJknKbwBF6EeakDfUE7IG9ikJLi1GOg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.13.1.tgz",
+      "integrity": "sha512-m2L/WcZKs5OMV6sINdfo0JZQrB1H8zZMTjh8+nlN+eZ1bCdRhqDmUluyftIduW6i9i+sIKK2MRtvXQChabNMTQ==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
         "@strapi/design-system": "1.9.0",
-        "@strapi/generators": "4.12.7",
-        "@strapi/helper-plugin": "4.12.7",
+        "@strapi/generators": "4.13.1",
+        "@strapi/helper-plugin": "4.13.1",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.12.7",
+        "@strapi/utils": "4.13.1",
         "fs-extra": "10.0.0",
         "immer": "9.0.19",
         "lodash": "4.17.21",
@@ -3210,17 +3211,18 @@
       }
     },
     "node_modules/@strapi/plugin-email": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.12.7.tgz",
-      "integrity": "sha512-trDovwklpQo4XWLyYyidpk65ooDteEMF/WICUYwclm5FRZ5Yi4g2vTa+6QSNwJXCk+ZwQXGlpCGG3Lw3yzkADA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.13.1.tgz",
+      "integrity": "sha512-VvX06ZjpyxRgoloRDfWMltyQGMbmffBd3j+f1BmLV5KL1cwyqOPdVaBrws9UJuUgPsCL8O8J9bAW+KxcVRmOew==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
         "@strapi/icons": "1.9.0",
-        "@strapi/provider-email-sendmail": "4.12.7",
-        "@strapi/utils": "4.12.7",
+        "@strapi/provider-email-sendmail": "4.13.1",
+        "@strapi/utils": "4.13.1",
         "lodash": "4.17.21",
         "prop-types": "^15.8.1",
         "react-intl": "6.4.1",
+        "react-query": "3.39.3",
         "yup": "0.32.9"
       },
       "engines": {
@@ -3235,14 +3237,14 @@
       }
     },
     "node_modules/@strapi/plugin-i18n": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-i18n/-/plugin-i18n-4.12.7.tgz",
-      "integrity": "sha512-1n1Il7jmlPe8fghEU/3yJOV0GRJqoovpFOt8jPUEHQbZqbdpg36en+DQzS/fSLtXZQSgHJlhbElJqLCjiV8z7A==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-i18n/-/plugin-i18n-4.13.1.tgz",
+      "integrity": "sha512-n0n/+BfgQ/c4xx6sYuh1cw12V8GTUVN+zQ/fBm2XW6nJOx6LGnHJPLa85QJOLFaIbC2oZR8tsFsyLl7e729hsw==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.12.7",
+        "@strapi/helper-plugin": "4.13.1",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.12.7",
+        "@strapi/utils": "4.13.1",
         "formik": "2.4.0",
         "immer": "9.0.19",
         "lodash": "4.17.21",
@@ -3266,16 +3268,16 @@
       }
     },
     "node_modules/@strapi/plugin-upload": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.12.7.tgz",
-      "integrity": "sha512-U93yzaEkEWseB2CHLQ7MOEDyUQ2MoBlZo963DSv9U11b/TirvnsJBwCfn6fZHZy09cQ6yr9F/CEqCGqEHsTqcw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.13.1.tgz",
+      "integrity": "sha512-OpaUSmO132ZVYl+LGrRQo/re4JejyAevvip/xuBHHM8lE2zDJCZG6VVTy4a9/eQF+c1uW1hEYSTtdlKs/64wpA==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.12.7",
+        "@strapi/helper-plugin": "4.13.1",
         "@strapi/icons": "1.9.0",
-        "@strapi/provider-upload-local": "4.12.7",
-        "@strapi/utils": "4.12.7",
-        "axios": "1.4.0",
+        "@strapi/provider-upload-local": "4.13.1",
+        "@strapi/utils": "4.13.1",
+        "axios": "1.5.0",
         "byte-size": "7.0.1",
         "cropperjs": "1.5.12",
         "date-fns": "2.30.0",
@@ -3309,14 +3311,14 @@
       }
     },
     "node_modules/@strapi/plugin-users-permissions": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.12.7.tgz",
-      "integrity": "sha512-dl7Ar1zVl0DWuL45FcYTPZDQDuS+S0FFbq+rjZBFBcmNHwAiGsw7jr+1PbGhb1Vc6N4EnDYXiLqDKawM8BiuBA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.13.1.tgz",
+      "integrity": "sha512-RDk3HN1Nv/mxAi45kU8HFDJFlIg+GjvLh0MYr0DXV7xdKtK4q/C1IZs4NNYs+javIhA4kiozEFiTiNRoHfxmKg==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.12.7",
+        "@strapi/helper-plugin": "4.13.1",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.12.7",
+        "@strapi/utils": "4.13.1",
         "bcryptjs": "2.4.3",
         "formik": "2.4.0",
         "grant-koa": "5.4.8",
@@ -3346,9 +3348,9 @@
       }
     },
     "node_modules/@strapi/provider-audit-logs-local": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.12.7.tgz",
-      "integrity": "sha512-V8gKlhwL5RK4cZabQSFqEk4h7pvAnobqIyY55vRqtl8XgyVyaAqLzJPhmFyDJXoms2IZvtUlZPLk3vN5i6XOLA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.13.1.tgz",
+      "integrity": "sha512-nuI5yHYdlAAAiSUGYtlmZUKqXowxjPJZnMGDKwBnnOO8P1dBXoUmdUqSD7mqSEAkdPeKxqpSTzzmrxtGxOvckQ==",
       "engines": {
         "node": ">=16.0.0 <=20.x.x",
         "npm": ">=6.0.0"
@@ -3358,11 +3360,11 @@
       }
     },
     "node_modules/@strapi/provider-email-sendmail": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.12.7.tgz",
-      "integrity": "sha512-oJL+aDntUbofdp3aBn9umTdENM5NastC0+R4MA+J+HtcGTzIlxCk5VwaJPQ8vimFjIDpsuj3InQLSE+UFRUEKA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.13.1.tgz",
+      "integrity": "sha512-mVNWkA6qdWUA7I0Pwz1Cw3Q540BhMJTlEz0BEy97iB9RPKDfN7KaisxJKdKisNxGSDHd9+m9+ejm1M9Wy116Gg==",
       "dependencies": {
-        "@strapi/utils": "4.12.7",
+        "@strapi/utils": "4.13.1",
         "sendmail": "^1.6.1"
       },
       "engines": {
@@ -3371,11 +3373,11 @@
       }
     },
     "node_modules/@strapi/provider-upload-aws-s3": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-aws-s3/-/provider-upload-aws-s3-4.12.7.tgz",
-      "integrity": "sha512-nYW447bfprLLnQ3gY9scXi4FT7ctPSZi1asbkpWDILCufdNSwZGxJUtYlJiii7Fwnv0PL2rnks0LP1WiEZwfew==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-aws-s3/-/provider-upload-aws-s3-4.13.1.tgz",
+      "integrity": "sha512-kTS7zUZ3Uoch1K+b9G1kimJPl/gpLJJOrrOwr+yC2UwTD4Ne+Icfda8+Z5CThNtgvkHKlQGWLqg3rCD53G9QWQ==",
       "dependencies": {
-        "aws-sdk": "2.1430.0",
+        "aws-sdk": "2.1437.0",
         "lodash": "4.17.21"
       },
       "engines": {
@@ -3384,11 +3386,11 @@
       }
     },
     "node_modules/@strapi/provider-upload-local": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-4.12.7.tgz",
-      "integrity": "sha512-3TzZNGPc/3p2UTCq4N6lRvbX494Km3HeR+cHLxt56DnX/tw9OXweJVWsYLuKq84BVp8I0U6b3FMNtGXI2wJryw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-4.13.1.tgz",
+      "integrity": "sha512-IqHoGnAuPDDt4Scix9heDBSmIqbUHZ0Z8rHhxjI/FMUHpKUO5OtMmukqeN9urtSm2wOndNRKxC5QnxdX7wSG/w==",
       "dependencies": {
-        "@strapi/utils": "4.12.7",
+        "@strapi/utils": "4.13.1",
         "fs-extra": "10.0.0"
       },
       "engines": {
@@ -3397,26 +3399,26 @@
       }
     },
     "node_modules/@strapi/strapi": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-4.12.7.tgz",
-      "integrity": "sha512-9cDdDN4tjNXw3jW2qUh/gc0GL7Rgcw4jRfeUnSeVgeEEduvQR3Cit2DIgdHeQvtaN+80Iwj4wCAOLs951o4Bwg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-4.13.1.tgz",
+      "integrity": "sha512-FI9RkcE2o3AMpwHI3Uk8WZ8v/5ByvilNL5eK2E0jbUzzXhnsW8QUlvUDOqrywS9Xp9J25xeSbxIPS44QVypIjA==",
       "hasInstallScript": true,
       "dependencies": {
         "@koa/cors": "3.4.3",
         "@koa/router": "10.1.1",
-        "@strapi/admin": "4.12.7",
-        "@strapi/data-transfer": "4.12.7",
-        "@strapi/database": "4.12.7",
-        "@strapi/generate-new": "4.12.7",
-        "@strapi/generators": "4.12.7",
-        "@strapi/logger": "4.12.7",
-        "@strapi/permissions": "4.12.7",
-        "@strapi/plugin-content-manager": "4.12.7",
-        "@strapi/plugin-content-type-builder": "4.12.7",
-        "@strapi/plugin-email": "4.12.7",
-        "@strapi/plugin-upload": "4.12.7",
-        "@strapi/typescript-utils": "4.12.7",
-        "@strapi/utils": "4.12.7",
+        "@strapi/admin": "4.13.1",
+        "@strapi/data-transfer": "4.13.1",
+        "@strapi/database": "4.13.1",
+        "@strapi/generate-new": "4.13.1",
+        "@strapi/generators": "4.13.1",
+        "@strapi/logger": "4.13.1",
+        "@strapi/permissions": "4.13.1",
+        "@strapi/plugin-content-manager": "4.13.1",
+        "@strapi/plugin-content-type-builder": "4.13.1",
+        "@strapi/plugin-email": "4.13.1",
+        "@strapi/plugin-upload": "4.13.1",
+        "@strapi/typescript-utils": "4.13.1",
+        "@strapi/utils": "4.13.1",
         "bcryptjs": "2.4.3",
         "boxen": "5.1.2",
         "chalk": "4.1.2",
@@ -3446,7 +3448,7 @@
         "koa-static": "5.0.0",
         "lodash": "4.17.21",
         "mime-types": "2.1.35",
-        "node-fetch": "2.6.9",
+        "node-fetch": "2.7.0",
         "node-machine-id": "1.1.12",
         "node-schedule": "2.1.0",
         "open": "8.4.0",
@@ -3466,9 +3468,9 @@
       }
     },
     "node_modules/@strapi/typescript-utils": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-4.12.7.tgz",
-      "integrity": "sha512-YFhB/0WfJpZxe0BJLbbtuPAtNwMMkozjooWzByn8Ah3UtSjef4otBsnuYy7ogruaxOH5cTCQ7E9w3gOyn/xpuw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-4.13.1.tgz",
+      "integrity": "sha512-dFTeHPPbwlhkdQJVTB2H0pb8ZnB+uwQQhU81vy5GpPYYIuVmso6KnkmkfdB+tI09+Buic9nxVfQmFJBy0q8rLg==",
       "dependencies": {
         "chalk": "4.1.2",
         "cli-table3": "0.6.2",
@@ -3515,9 +3517,9 @@
       }
     },
     "node_modules/@strapi/utils": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-4.12.7.tgz",
-      "integrity": "sha512-M+huzEKfLVbwrWN9SwTGVZVNLAjMVtqmd21sCOKMp8sEtqSR62g9Ovr6XZHWHgl/m7nlqdpaQLJM9vLChMXMgA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-4.13.1.tgz",
+      "integrity": "sha512-IW0ac0aeJbE6wptzW/7yZ4KPwRaqshHtNPCOrWAnG0L1Is/UkpwVUBUSmWq12m1utJF+nIenwgHH8jbKYolhFw==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
         "date-fns": "2.30.0",
@@ -3855,9 +3857,9 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
     },
     "node_modules/@types/node": {
-      "version": "20.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.4.tgz",
-      "integrity": "sha512-Y9vbIAoM31djQZrPYjpTLo0XlaSwOIsrlfE3LpulZeRblttsLQRFRlBAppW0LOxyT3ALj2M5vU1ucQQayQH3jA=="
+      "version": "20.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -3870,9 +3872,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+      "version": "6.9.8",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
+      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
@@ -4029,9 +4031,9 @@
       }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.9.tgz",
-      "integrity": "sha512-TQT6aF8brxZpFnk/K4fm/K/9k9eF3PMav/KKjHlYrGUT8BTNk/qL+ximLtIzvTUhmBFchjM1lrqSJdvpVom7/w==",
+      "version": "4.21.12",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.12.tgz",
+      "integrity": "sha512-LNAr5ZmKjo9KpnoVhnAiXkRsI+l9JrIrUPc3+GjpbTi8k9QjEcs8y3MFvhA2le7bbf6q1gHh2UbLmn6le0cGjQ==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -4052,15 +4054,15 @@
       }
     },
     "node_modules/@uiw/react-codemirror": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.9.tgz",
-      "integrity": "sha512-aeLegPz2iCvqJjhzXp2WUMqpMZDqxsTnF3rX9kGRlfY6vQLsrjoctj0cQ29uxEtFYJChOVjtCOtnQUlyIuNAHQ==",
+      "version": "4.21.12",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.12.tgz",
+      "integrity": "sha512-dgPhw2QLcXMe004UU8b8P0Y6Zu+AKoGXbioLF2dY2/wLeMWSXCCbKo/BKJGj/skoO/lBJ4X+b+14OGuZ5Uyeaw==",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/state": "^6.1.1",
         "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.21.9",
+        "@uiw/codemirror-extensions-basic-setup": "4.21.12",
         "codemirror": "^6.0.0"
       },
       "peerDependencies": {
@@ -4673,9 +4675,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1430.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1430.0.tgz",
-      "integrity": "sha512-827BjW9Q9NwUucZBHHU64dh96ihE857LC0ZOEub0C5wjxujoEqET0i4qJR7k+/wn8tFMNtWO0rIGCSGSmgrm5A==",
+      "version": "2.1437.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1437.0.tgz",
+      "integrity": "sha512-ApsAHaeDQFXM8y6OcRLMzUKXVgDZXPJtq1MLG7cqrKkRIugLMTx3j0UHFfF5j6hLHfX0KWrIOCwXEo6qUjviZQ==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -4693,9 +4695,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -5443,9 +5445,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001522",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
-      "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==",
+      "version": "1.0.30001525",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
+      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -5853,9 +5855,9 @@
     },
     "node_modules/codemirror5": {
       "name": "codemirror",
-      "version": "5.65.14",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.14.tgz",
-      "integrity": "sha512-VSNugIBDGt0OU9gDjeVr6fNkoFQznrWEUdAApMlXQNbfE8gGO19776D6MwSqF/V/w/sDwonsQ0z7KmmI9guScg=="
+      "version": "5.65.15",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.15.tgz",
+      "integrity": "sha512-YC4EHbbwQeubZzxLl5G4nlbLc1T21QTrKGaOal/Pkm9dVDMZXMH7+ieSPEOZCtO9I68i8/oteJKOxzHC2zR+0g=="
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
@@ -6841,9 +6843,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.500",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.500.tgz",
-      "integrity": "sha512-P38NO8eOuWOKY1sQk5yE0crNtrjgjJj6r3NrbIKtG18KzCHmHE2Bt+aQA7/y0w3uYsHWxDa6icOohzjLJ4vJ4A=="
+      "version": "1.4.506",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.506.tgz",
+      "integrity": "sha512-xxGct4GPAKSRlrLBtJxJFYy74W11zX6PO9GyHgl/U+2s3Dp0ZEwAklDfNHXOWcvH7zWMpsmgbR0ggEuaYAVvHA=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -11755,9 +11757,9 @@
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -12700,9 +12702,9 @@
       }
     },
     "node_modules/patch-package/node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
       "engines": {
         "node": ">= 14"
       }
@@ -13244,9 +13246,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.28",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
-      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
+      "version": "8.4.29",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
+      "integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
       "funding": [
         {
           "type": "opencollective",
@@ -16065,9 +16067,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.19.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.2.tgz",
-      "integrity": "sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==",
+      "version": "5.19.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.3.tgz",
+      "integrity": "sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@strapi/plugin-i18n": "4.13.1",
-        "@strapi/plugin-users-permissions": "4.13.1",
-        "@strapi/provider-upload-aws-s3": "4.13.1",
-        "@strapi/strapi": "4.13.1",
+        "@strapi/plugin-i18n": "4.13.2",
+        "@strapi/plugin-users-permissions": "4.13.2",
+        "@strapi/provider-upload-aws-s3": "4.13.2",
+        "@strapi/strapi": "4.13.2",
         "patch-package": "^8.0.0",
         "pg": "^8.11.3",
         "pluralize": "^8.0.0",
@@ -126,20 +126,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.11.tgz",
-      "integrity": "sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.15.tgz",
+      "integrity": "sha512-PtZqMmgRrvj8ruoEOIwVA3yoF91O+Hgw9o7DAUTNBA6Mo2jpu31clx9a7Nz/9JznqetTR6zwfC4L3LAjKQXUwA==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.10",
-        "@babel/generator": "^7.22.10",
-        "@babel/helper-compilation-targets": "^7.22.10",
-        "@babel/helper-module-transforms": "^7.22.9",
-        "@babel/helpers": "^7.22.11",
-        "@babel/parser": "^7.22.11",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.11",
-        "@babel/types": "^7.22.11",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.22.15",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.22.15",
+        "@babel/helpers": "^7.22.15",
+        "@babel/parser": "^7.22.15",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.22.15",
+        "@babel/types": "^7.22.15",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -168,11 +168,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
-      "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
+      "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
       "dependencies": {
-        "@babel/types": "^7.22.10",
+        "@babel/types": "^7.22.15",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -193,12 +193,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
-      "integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.5",
+        "@babel/helper-validator-option": "^7.22.15",
         "browserslist": "^4.21.9",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -247,26 +247,26 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-      "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
-      "integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.15.tgz",
+      "integrity": "sha512-l1UiX4UyHSFsYt17iQ3Se5pQQZZHa22zyIXURmvkmLCD4t/aU+dvNWHatKac/D9Vm9UES7nvIqHs4jZqKviUmQ==",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-simple-access": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.5"
+        "@babel/helper-validator-identifier": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -314,29 +314,29 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
+      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.11.tgz",
-      "integrity": "sha512-vyOXC8PBWaGc5h7GMsNx68OH33cypkEDJCHvYVVgVbbxJDROYVtexSk0gK5iCF1xNjRIN2s8ai7hwkWDq5szWg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.15.tgz",
+      "integrity": "sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==",
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.11",
-        "@babel/types": "^7.22.11"
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -420,9 +420,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.14",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
-      "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.15.tgz",
+      "integrity": "sha512-RWmQ/sklUN9BvGGpCDgSubhHWfAx24XDTDObup4ffvxaYsptOg2P3KG0j+1eWKLxpkX0j0uHxmpq2Z1SP/VhxA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -607,9 +607,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
-      "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
+      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -618,9 +618,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.22.11.tgz",
-      "integrity": "sha512-NhfzUbdWbiE6fCFypbWCPu6AR8xre31EOPF7wwAIJEvGQ2avov04eymayWinCuyXmV1b0+jzoXP/HYzzUYdvwg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.22.15.tgz",
+      "integrity": "sha512-SAj8oKi8UogVi6eXQXKNPu8qZ78Yzy7zawrlTr0M+IuW/g8Qe9gVDhGcF9h1S69OyACpYoLxEzpjs1M15sI5wQ==",
       "dependencies": {
         "core-js-pure": "^3.30.2",
         "regenerator-runtime": "^0.14.0"
@@ -630,31 +630,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-      "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/parser": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.11.tgz",
-      "integrity": "sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.15.tgz",
+      "integrity": "sha512-DdHPwvJY0sEeN4xJU5uRLmZjgMMDIvMPniLuYzUVXj/GGzysPl0/fwt44JBkyUIzGJPV8QgHMcQdQ34XFuKTYQ==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.10",
-        "@babel/generator": "^7.22.10",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.22.15",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.11",
-        "@babel/types": "^7.22.11",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -663,12 +663,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
-      "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.15.tgz",
+      "integrity": "sha512-X+NLXr0N8XXmN5ZsaQdm9U2SSC3UbIYq/doL++sueHOTisgZHoKaQtZxGuV2cUPQHMfjKEfg/g6oy7Hm6SKFtA==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.15",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -779,9 +779,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.17.0.tgz",
-      "integrity": "sha512-0yVhPSyKWwYDy6Xwd7aDoj8ZXtdoHwC7El4z1/JJpIimrtDR5CVGY4lvQ0r2hP11ezB+eCHexZ6Zbz6rPUe06A==",
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.17.1.tgz",
+      "integrity": "sha512-I5KVxsLbm1f56n9SUajLW0/AzMXYEZVvkiYahMw/yGl5gUjT2WquuKO39xUtiT4z/hNhGD7YuAEVPI8u0mncaQ==",
       "dependencies": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.1.0",
@@ -2880,20 +2880,20 @@
       }
     },
     "node_modules/@strapi/admin": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-4.13.1.tgz",
-      "integrity": "sha512-hZ9ExxkldkyLzLuRGgAmMIPHkmZXRWrzU4AVOYuTF2Ov1Hwq4RLAMudFe5fdNHYQM/0Cyls5Lio2DI3d8SUfrg==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-4.13.2.tgz",
+      "integrity": "sha512-CrgOT7ioofDeq/+TYTTso0YqnB8o+pmUHCyzujh/+EOGK843rT1igaYiESRKt9Ey6Nfq52WQAT+5cNuGtYcDSQ==",
       "dependencies": {
         "@casl/ability": "^5.4.3",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
-        "@strapi/data-transfer": "4.13.1",
+        "@strapi/data-transfer": "4.13.2",
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.1",
+        "@strapi/helper-plugin": "4.13.2",
         "@strapi/icons": "1.9.0",
-        "@strapi/permissions": "4.13.1",
-        "@strapi/provider-audit-logs-local": "4.13.1",
-        "@strapi/typescript-utils": "4.13.1",
-        "@strapi/utils": "4.13.1",
+        "@strapi/permissions": "4.13.2",
+        "@strapi/provider-audit-logs-local": "4.13.2",
+        "@strapi/typescript-utils": "4.13.2",
+        "@strapi/utils": "4.13.2",
         "axios": "1.5.0",
         "bcryptjs": "2.4.3",
         "browserslist": "^4.17.3",
@@ -2981,12 +2981,12 @@
       }
     },
     "node_modules/@strapi/data-transfer": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-4.13.1.tgz",
-      "integrity": "sha512-eEZEayF5WvvxjMD0UiBYvncRws5ocdOjaDjhPBKR1Grx9UEdzMrJi79paoylAO930dIkbSpsEmmIvImWpdXWNA==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-4.13.2.tgz",
+      "integrity": "sha512-rd9urF2iePbFBA4Al4J1l/vv+DHP0IBNjGddaJ4e/kTHIgWlLo8TrASBmESqEkV++pOnHUfwV+yJKYCUJby5jQ==",
       "dependencies": {
-        "@strapi/logger": "4.13.1",
-        "@strapi/strapi": "4.13.1",
+        "@strapi/logger": "4.13.2",
+        "@strapi/strapi": "4.13.2",
         "chalk": "4.1.2",
         "fs-extra": "10.0.0",
         "lodash": "4.17.21",
@@ -3006,11 +3006,11 @@
       }
     },
     "node_modules/@strapi/database": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-4.13.1.tgz",
-      "integrity": "sha512-9AeyONaHdaqL7/El1vyM3cw3s3brt8d4aiFUIhGLCWVZMJAVxRgobo/KtUCpdFuH0jHxxWbNz/hkjVBiYPm+PA==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-4.13.2.tgz",
+      "integrity": "sha512-N8Uqh7jh2guHtEz9GXwJWCjTYXe41sjknKK59MVwHG0P3a85qmKRqGcQr0pWiug+k3O5Ny/GOdVCJKBZE64zig==",
       "dependencies": {
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.13.2",
         "date-fns": "2.30.0",
         "debug": "4.3.4",
         "fs-extra": "10.0.0",
@@ -3052,9 +3052,9 @@
       }
     },
     "node_modules/@strapi/generate-new": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/generate-new/-/generate-new-4.13.1.tgz",
-      "integrity": "sha512-YI7uP9HcELZAAHCslpXetoWfNW5XnCknreq5accKUm1kpQtE9gPfiUABgorx52RCLVyklJoH6/1wlBmJ0n0F4g==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/generate-new/-/generate-new-4.13.2.tgz",
+      "integrity": "sha512-1HgafgHLDMnl2X5Hzqr1h+c9EVVDSAMLscxfjTBdCSgxORM1TDC6zqgLJ90qRu2x9mWOTZET0OSXILI5WbVrOA==",
       "dependencies": {
         "@sentry/node": "6.19.7",
         "chalk": "^4.1.2",
@@ -3074,13 +3074,13 @@
       }
     },
     "node_modules/@strapi/generators": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-4.13.1.tgz",
-      "integrity": "sha512-YzFwJ+7pyFSMKEp9iDoDjDr769QP2PEhPGrRcnztKI7bCKCAs28xz0ff0hPKvPvDpbz83+1Yu3+yLEatcNZqRQ==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-4.13.2.tgz",
+      "integrity": "sha512-dNXmjT68+uK5QqqPh0P+ZegdrII2ClAyjzzbMHnnBYq5Lu1sOJYB894E0h6DCRky7kdWbe38JHjeKo1PISyqfA==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/typescript-utils": "4.13.1",
-        "@strapi/utils": "4.13.1",
+        "@strapi/typescript-utils": "4.13.2",
+        "@strapi/utils": "4.13.2",
         "chalk": "4.1.2",
         "copyfiles": "2.4.1",
         "fs-extra": "10.0.0",
@@ -3094,9 +3094,9 @@
       }
     },
     "node_modules/@strapi/helper-plugin": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.13.1.tgz",
-      "integrity": "sha512-qUxUuVfeeXSmTEKykqEq36Y56iwg0WfZRK1xREuiLiLWguah7LpN1WEieZbItsMK8C/S6g4QNn9j78bx5vOvrg==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.13.2.tgz",
+      "integrity": "sha512-l1VFAxjVb2kyEG5kto1WAi9g1SAdR4+4GTIAzIVCMFdhaYdo40QUvpnb9Ji5q5N0KCaLi6CTrIjFKBXNme1HtA==",
       "dependencies": {
         "axios": "1.5.0",
         "date-fns": "2.30.0",
@@ -3133,9 +3133,9 @@
       }
     },
     "node_modules/@strapi/logger": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-4.13.1.tgz",
-      "integrity": "sha512-JM6GX+XWSR1p6A7JU4D40MbhgXbKf49Rf2aJSIxlqZa/usGFa+DlEnzF9c+0DUw+XFj9oF+8CPebRbwRw4CmAQ==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-4.13.2.tgz",
+      "integrity": "sha512-iXcW8rdcrTJPNkLlMXu094wmmSDl1UoCLH0iUnKF6cizzWpHwCm36E/Nq6uCARtYrpVcpog4fl+EWvBvhsAbQw==",
       "dependencies": {
         "lodash": "4.17.21",
         "winston": "3.10.0"
@@ -3146,12 +3146,12 @@
       }
     },
     "node_modules/@strapi/permissions": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-4.13.1.tgz",
-      "integrity": "sha512-yPL0/4gFrCkSbW1wB8EblWVGK1rU5+BFFoyEfLNoV91vq+ZE6LsVYaGP4mjtdAy6QaEfT5CD/9F3RsL2H7KKYg==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-4.13.2.tgz",
+      "integrity": "sha512-2TW8oNgZt56Vnej4w3EgkiZwm7MzRYpu3MZQ6EFLaquZyexv3atelDNxac6dJI6GgA3yYtC+2zkPLxnMcJSHbQ==",
       "dependencies": {
         "@casl/ability": "5.4.4",
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.13.2",
         "lodash": "4.17.21",
         "sift": "16.0.1"
       },
@@ -3161,12 +3161,12 @@
       }
     },
     "node_modules/@strapi/plugin-content-manager": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-manager/-/plugin-content-manager-4.13.1.tgz",
-      "integrity": "sha512-A11YCpsgnfNp4qqVaSGLhpe3ayKwmTpxfU1+FU3xNy2FJiP/26l17hJ2Dmn1PC/w6AIS+6LC+rZtURzpF2Yz+g==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-manager/-/plugin-content-manager-4.13.2.tgz",
+      "integrity": "sha512-dOVcT9nBc15cTYTCtabbCCsi0czjj5q0UUCLtvNEtr2jEUFKK+16ATQWCXZXtiKpaCEwXu21BB8Rt9FUMEUUuQ==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.13.2",
         "lodash": "4.17.21",
         "qs": "6.11.1"
       },
@@ -3176,16 +3176,16 @@
       }
     },
     "node_modules/@strapi/plugin-content-type-builder": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.13.1.tgz",
-      "integrity": "sha512-m2L/WcZKs5OMV6sINdfo0JZQrB1H8zZMTjh8+nlN+eZ1bCdRhqDmUluyftIduW6i9i+sIKK2MRtvXQChabNMTQ==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.13.2.tgz",
+      "integrity": "sha512-dPc1Vtz1mjUcrk/gu2Tjz/+DQN0JSyP0IbUl8eRVZoMDV0fvB+rNYUIgPy7x+Kr/x9rc1yugSbEMLvinbvluhA==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
         "@strapi/design-system": "1.9.0",
-        "@strapi/generators": "4.13.1",
-        "@strapi/helper-plugin": "4.13.1",
+        "@strapi/generators": "4.13.2",
+        "@strapi/helper-plugin": "4.13.2",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.13.2",
         "fs-extra": "10.0.0",
         "immer": "9.0.19",
         "lodash": "4.17.21",
@@ -3211,14 +3211,14 @@
       }
     },
     "node_modules/@strapi/plugin-email": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.13.1.tgz",
-      "integrity": "sha512-VvX06ZjpyxRgoloRDfWMltyQGMbmffBd3j+f1BmLV5KL1cwyqOPdVaBrws9UJuUgPsCL8O8J9bAW+KxcVRmOew==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.13.2.tgz",
+      "integrity": "sha512-bzdhtSRH2kj5pGGI3t5Uf3UwwmaTdT7xdp5gXjESppU0SMpksTCS/vuTl1ED/GZWDnkW6jy+vnX40AvLfp47ew==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
         "@strapi/icons": "1.9.0",
-        "@strapi/provider-email-sendmail": "4.13.1",
-        "@strapi/utils": "4.13.1",
+        "@strapi/provider-email-sendmail": "4.13.2",
+        "@strapi/utils": "4.13.2",
         "lodash": "4.17.21",
         "prop-types": "^15.8.1",
         "react-intl": "6.4.1",
@@ -3237,14 +3237,14 @@
       }
     },
     "node_modules/@strapi/plugin-i18n": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-i18n/-/plugin-i18n-4.13.1.tgz",
-      "integrity": "sha512-n0n/+BfgQ/c4xx6sYuh1cw12V8GTUVN+zQ/fBm2XW6nJOx6LGnHJPLa85QJOLFaIbC2oZR8tsFsyLl7e729hsw==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-i18n/-/plugin-i18n-4.13.2.tgz",
+      "integrity": "sha512-ZW/53Vc4HFg2VR1aAP8CrMC2WECw6X3tphsVDGdnf6Z7yAvVACVBj3gL8cojfpnGMt4lCQkq/jwkZOR7N4g42A==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.1",
+        "@strapi/helper-plugin": "4.13.2",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.13.2",
         "formik": "2.4.0",
         "immer": "9.0.19",
         "lodash": "4.17.21",
@@ -3268,18 +3268,18 @@
       }
     },
     "node_modules/@strapi/plugin-upload": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.13.1.tgz",
-      "integrity": "sha512-OpaUSmO132ZVYl+LGrRQo/re4JejyAevvip/xuBHHM8lE2zDJCZG6VVTy4a9/eQF+c1uW1hEYSTtdlKs/64wpA==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.13.2.tgz",
+      "integrity": "sha512-19MfRMQHqWiPyGab717RpbwD7XWA+k+LvOLxVriK3qP5zMjuEiFVs7LZ2q8+jAaJdlyXk1iyr3LQQCxFJAvBdw==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.1",
+        "@strapi/helper-plugin": "4.13.2",
         "@strapi/icons": "1.9.0",
-        "@strapi/provider-upload-local": "4.13.1",
-        "@strapi/utils": "4.13.1",
+        "@strapi/provider-upload-local": "4.13.2",
+        "@strapi/utils": "4.13.2",
         "axios": "1.5.0",
         "byte-size": "7.0.1",
-        "cropperjs": "1.5.12",
+        "cropperjs": "1.6.0",
         "date-fns": "2.30.0",
         "formik": "2.4.0",
         "fs-extra": "10.0.0",
@@ -3311,14 +3311,14 @@
       }
     },
     "node_modules/@strapi/plugin-users-permissions": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.13.1.tgz",
-      "integrity": "sha512-RDk3HN1Nv/mxAi45kU8HFDJFlIg+GjvLh0MYr0DXV7xdKtK4q/C1IZs4NNYs+javIhA4kiozEFiTiNRoHfxmKg==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.13.2.tgz",
+      "integrity": "sha512-RnBPMJ9w/3P4k4GlW/KykTqXNrHW2FJbo2/1vAjNX8M9nmiW5zmehZZeE9TIW3JgkQroLAnSkfjRBn97gkxumg==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.1",
+        "@strapi/helper-plugin": "4.13.2",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.13.2",
         "bcryptjs": "2.4.3",
         "formik": "2.4.0",
         "grant-koa": "5.4.8",
@@ -3348,9 +3348,9 @@
       }
     },
     "node_modules/@strapi/provider-audit-logs-local": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.13.1.tgz",
-      "integrity": "sha512-nuI5yHYdlAAAiSUGYtlmZUKqXowxjPJZnMGDKwBnnOO8P1dBXoUmdUqSD7mqSEAkdPeKxqpSTzzmrxtGxOvckQ==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.13.2.tgz",
+      "integrity": "sha512-jj9KjOo68KCQ9BNbZnvXuPZuR9UPpCk9BYQ9nHLK4k7KmtcclxguuO673fK/bzQJrMT5uVQrWQVGSpCxa7CkvQ==",
       "engines": {
         "node": ">=16.0.0 <=20.x.x",
         "npm": ">=6.0.0"
@@ -3360,11 +3360,11 @@
       }
     },
     "node_modules/@strapi/provider-email-sendmail": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.13.1.tgz",
-      "integrity": "sha512-mVNWkA6qdWUA7I0Pwz1Cw3Q540BhMJTlEz0BEy97iB9RPKDfN7KaisxJKdKisNxGSDHd9+m9+ejm1M9Wy116Gg==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.13.2.tgz",
+      "integrity": "sha512-K7bGuF1gD7N8jMhvCtGI6eYskb5aaq+4aLrx+vSWN5zDOgP+bfiGDdX119/ziH82chSO2IyYu/5SmK/8V9hueQ==",
       "dependencies": {
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.13.2",
         "sendmail": "^1.6.1"
       },
       "engines": {
@@ -3373,9 +3373,9 @@
       }
     },
     "node_modules/@strapi/provider-upload-aws-s3": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-aws-s3/-/provider-upload-aws-s3-4.13.1.tgz",
-      "integrity": "sha512-kTS7zUZ3Uoch1K+b9G1kimJPl/gpLJJOrrOwr+yC2UwTD4Ne+Icfda8+Z5CThNtgvkHKlQGWLqg3rCD53G9QWQ==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-aws-s3/-/provider-upload-aws-s3-4.13.2.tgz",
+      "integrity": "sha512-VgqbyRCWMg6MTNxhMMv2AYChmPOFjOUTsmCPm3uvPbG+CynuX9+9USBMhfTkfZ06kVuHiOSH4jm2LyantmjXmQ==",
       "dependencies": {
         "aws-sdk": "2.1437.0",
         "lodash": "4.17.21"
@@ -3386,11 +3386,11 @@
       }
     },
     "node_modules/@strapi/provider-upload-local": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-4.13.1.tgz",
-      "integrity": "sha512-IqHoGnAuPDDt4Scix9heDBSmIqbUHZ0Z8rHhxjI/FMUHpKUO5OtMmukqeN9urtSm2wOndNRKxC5QnxdX7wSG/w==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-4.13.2.tgz",
+      "integrity": "sha512-+3vQXNWgblQsP3XRHtktgTFeomo2fpVbM9cJmeN5kDICz+RwuM2yG5zT4e2vqvkLS14BI0M7c4UJz+j7qitP/g==",
       "dependencies": {
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.13.2",
         "fs-extra": "10.0.0"
       },
       "engines": {
@@ -3399,26 +3399,26 @@
       }
     },
     "node_modules/@strapi/strapi": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-4.13.1.tgz",
-      "integrity": "sha512-FI9RkcE2o3AMpwHI3Uk8WZ8v/5ByvilNL5eK2E0jbUzzXhnsW8QUlvUDOqrywS9Xp9J25xeSbxIPS44QVypIjA==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-4.13.2.tgz",
+      "integrity": "sha512-pqjLDmiRPcpO0rAt74Z4w4clsKpHGpG0FfHzoTj7HCqzDUdnnNsbAUCekF7681C91jG1Syj40Mqt7fP198X9lw==",
       "hasInstallScript": true,
       "dependencies": {
         "@koa/cors": "3.4.3",
         "@koa/router": "10.1.1",
-        "@strapi/admin": "4.13.1",
-        "@strapi/data-transfer": "4.13.1",
-        "@strapi/database": "4.13.1",
-        "@strapi/generate-new": "4.13.1",
-        "@strapi/generators": "4.13.1",
-        "@strapi/logger": "4.13.1",
-        "@strapi/permissions": "4.13.1",
-        "@strapi/plugin-content-manager": "4.13.1",
-        "@strapi/plugin-content-type-builder": "4.13.1",
-        "@strapi/plugin-email": "4.13.1",
-        "@strapi/plugin-upload": "4.13.1",
-        "@strapi/typescript-utils": "4.13.1",
-        "@strapi/utils": "4.13.1",
+        "@strapi/admin": "4.13.2",
+        "@strapi/data-transfer": "4.13.2",
+        "@strapi/database": "4.13.2",
+        "@strapi/generate-new": "4.13.2",
+        "@strapi/generators": "4.13.2",
+        "@strapi/logger": "4.13.2",
+        "@strapi/permissions": "4.13.2",
+        "@strapi/plugin-content-manager": "4.13.2",
+        "@strapi/plugin-content-type-builder": "4.13.2",
+        "@strapi/plugin-email": "4.13.2",
+        "@strapi/plugin-upload": "4.13.2",
+        "@strapi/typescript-utils": "4.13.2",
+        "@strapi/utils": "4.13.2",
         "bcryptjs": "2.4.3",
         "boxen": "5.1.2",
         "chalk": "4.1.2",
@@ -3468,9 +3468,9 @@
       }
     },
     "node_modules/@strapi/typescript-utils": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-4.13.1.tgz",
-      "integrity": "sha512-dFTeHPPbwlhkdQJVTB2H0pb8ZnB+uwQQhU81vy5GpPYYIuVmso6KnkmkfdB+tI09+Buic9nxVfQmFJBy0q8rLg==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-4.13.2.tgz",
+      "integrity": "sha512-Rd4NlxfSlMEWVBnXWK+obFNVF71HJp2Z6XA8WnKEtTk/gNHAdkkhmweTgYkC7Qxgy2aOX2Blllyd4A3wpwsWsg==",
       "dependencies": {
         "chalk": "4.1.2",
         "cli-table3": "0.6.2",
@@ -3517,9 +3517,9 @@
       }
     },
     "node_modules/@strapi/utils": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-4.13.1.tgz",
-      "integrity": "sha512-IW0ac0aeJbE6wptzW/7yZ4KPwRaqshHtNPCOrWAnG0L1Is/UkpwVUBUSmWq12m1utJF+nIenwgHH8jbKYolhFw==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-4.13.2.tgz",
+      "integrity": "sha512-f/6RzMP37aaBvyhwyJhVmF8x2e9P0A+nO4tsIgPy8BJ6gIf5rblZHsiTAYnOkPaZkKiBR3i0bxq3lXe1+0c1hA==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
         "date-fns": "2.30.0",
@@ -3642,17 +3642,17 @@
       }
     },
     "node_modules/@types/connect": {
-      "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "version": "3.4.36",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
+      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/connect-history-api-fallback": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-      "integrity": "sha512-4x5FkPpLipqwthjPsF7ZRbOv3uoLUFkTA9G9v583qi4pACvq0uTELrB8OLUzPWUI4IJIyvM85vzkV1nyiI2Lig==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.1.tgz",
+      "integrity": "sha512-iaQslNbARe8fctL5Lk+DsmgWOM83lM+7FzP0eQUJs1jd3kBE8NWqBTIT2S8SqQOJjxvt2eyIjpOuYeRXq2AdMw==",
       "dependencies": {
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
@@ -3857,9 +3857,9 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
     },
     "node_modules/@types/node": {
-      "version": "20.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
-      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
+      "version": "20.5.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
+      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -4031,9 +4031,9 @@
       }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.21.12",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.12.tgz",
-      "integrity": "sha512-LNAr5ZmKjo9KpnoVhnAiXkRsI+l9JrIrUPc3+GjpbTi8k9QjEcs8y3MFvhA2le7bbf6q1gHh2UbLmn6le0cGjQ==",
+      "version": "4.21.13",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.13.tgz",
+      "integrity": "sha512-5ObHaBqPV00xBVleDFehzPfOQvek5dPM7YLdPHJUE9bumeSflIWJb55n0Zg/w1rsuU0Lt/Q6WJUh4X6VGR1FVw==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -4054,15 +4054,15 @@
       }
     },
     "node_modules/@uiw/react-codemirror": {
-      "version": "4.21.12",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.12.tgz",
-      "integrity": "sha512-dgPhw2QLcXMe004UU8b8P0Y6Zu+AKoGXbioLF2dY2/wLeMWSXCCbKo/BKJGj/skoO/lBJ4X+b+14OGuZ5Uyeaw==",
+      "version": "4.21.13",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.13.tgz",
+      "integrity": "sha512-kNX8jLeoDrF2CDa5lsey0MXjBXN3JP00z6AQTTP58mHvlE7Rf03QJSs7bNwwco+3kpwREifFJjnwRe+Y3Gmwtw==",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/state": "^6.1.1",
         "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.21.12",
+        "@uiw/codemirror-extensions-basic-setup": "4.21.13",
         "codemirror": "^6.0.0"
       },
       "peerDependencies": {
@@ -5445,9 +5445,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001525",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
-      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
+      "version": "1.0.30001527",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001527.tgz",
+      "integrity": "sha512-YkJi7RwPgWtXVSgK4lG9AHH57nSzvvOp9MesgXmw4Q7n0C3H04L0foHqfxcmSAm5AcWb8dW9AYj2tR7/5GnddQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6277,9 +6277,9 @@
       }
     },
     "node_modules/cropperjs": {
-      "version": "1.5.12",
-      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.5.12.tgz",
-      "integrity": "sha512-re7UdjE5UnwdrovyhNzZ6gathI4Rs3KGCBSc8HCIjUo5hO42CtzyblmWLj6QWVw7huHyDMfpKxhiO2II77nhDw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.6.0.tgz",
+      "integrity": "sha512-BzLU/ecrfsbflwxgu+o7sQTrTlo52pVRZkTVrugEK5uyj6n8qKwAHP4s6+DWHqlXLqQ5B9+cM2MKeXiNfAsF6Q=="
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -6843,9 +6843,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.506",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.506.tgz",
-      "integrity": "sha512-xxGct4GPAKSRlrLBtJxJFYy74W11zX6PO9GyHgl/U+2s3Dp0ZEwAklDfNHXOWcvH7zWMpsmgbR0ggEuaYAVvHA=="
+      "version": "1.4.508",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.508.tgz",
+      "integrity": "sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -13563,9 +13563,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
-      "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.3.tgz",
+      "integrity": "sha512-KddyFewCsO0j3+np81IQ+SweXLDnDQTs5s67BOnrYmYe/yNmUhttQyGsYzy8yUnoljGAQ9sl38YB4vH8ur7Y+w==",
       "dev": true,
       "funding": [
         {
@@ -16067,9 +16067,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.19.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.3.tgz",
-      "integrity": "sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==",
+      "version": "5.19.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.4.tgz",
+      "integrity": "sha512-6p1DjHeuluwxDXcuT9VR8p64klWJKo1ILiy19s6C9+0Bh2+NWTX6nD9EPppiER4ICkHDVB1RkVpin/YW2nQn/g==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@strapi/plugin-i18n": "4.13.2",
-        "@strapi/plugin-users-permissions": "4.13.2",
-        "@strapi/provider-upload-aws-s3": "4.13.2",
-        "@strapi/strapi": "4.13.2",
+        "@strapi/plugin-i18n": "4.13.3",
+        "@strapi/plugin-users-permissions": "4.13.3",
+        "@strapi/provider-upload-aws-s3": "4.13.3",
+        "@strapi/strapi": "4.13.3",
         "patch-package": "^8.0.0",
         "pg": "^8.11.3",
         "pluralize": "^8.0.0",
@@ -420,9 +420,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.15.tgz",
-      "integrity": "sha512-RWmQ/sklUN9BvGGpCDgSubhHWfAx24XDTDObup4ffvxaYsptOg2P3KG0j+1eWKLxpkX0j0uHxmpq2Z1SP/VhxA==",
+      "version": "7.22.16",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
+      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -779,9 +779,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.17.1.tgz",
-      "integrity": "sha512-I5KVxsLbm1f56n9SUajLW0/AzMXYEZVvkiYahMw/yGl5gUjT2WquuKO39xUtiT4z/hNhGD7YuAEVPI8u0mncaQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.18.0.tgz",
+      "integrity": "sha512-T6q1yYAoU+gSWfJFR4ryvDQcyOqS+Mw5RCvh26y0KiNksOOLYhNvdB3BTyLz8vy4fKaYlzbAOyBU7OQPUGHzjQ==",
       "dependencies": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.1.0",
@@ -2880,20 +2880,20 @@
       }
     },
     "node_modules/@strapi/admin": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-4.13.2.tgz",
-      "integrity": "sha512-CrgOT7ioofDeq/+TYTTso0YqnB8o+pmUHCyzujh/+EOGK843rT1igaYiESRKt9Ey6Nfq52WQAT+5cNuGtYcDSQ==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-4.13.3.tgz",
+      "integrity": "sha512-EfCoGYhre0Ao8U19PkkZ44k3CKX4vplkOLL6eow/s0wYSh1U29yYidg0YM3bv8saM4Cfv+3B1jv7sGuBvOCB2A==",
       "dependencies": {
         "@casl/ability": "^5.4.3",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
-        "@strapi/data-transfer": "4.13.2",
+        "@strapi/data-transfer": "4.13.3",
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.2",
+        "@strapi/helper-plugin": "4.13.3",
         "@strapi/icons": "1.9.0",
-        "@strapi/permissions": "4.13.2",
-        "@strapi/provider-audit-logs-local": "4.13.2",
-        "@strapi/typescript-utils": "4.13.2",
-        "@strapi/utils": "4.13.2",
+        "@strapi/permissions": "4.13.3",
+        "@strapi/provider-audit-logs-local": "4.13.3",
+        "@strapi/typescript-utils": "4.13.3",
+        "@strapi/utils": "4.13.3",
         "axios": "1.5.0",
         "bcryptjs": "2.4.3",
         "browserslist": "^4.17.3",
@@ -2981,12 +2981,12 @@
       }
     },
     "node_modules/@strapi/data-transfer": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-4.13.2.tgz",
-      "integrity": "sha512-rd9urF2iePbFBA4Al4J1l/vv+DHP0IBNjGddaJ4e/kTHIgWlLo8TrASBmESqEkV++pOnHUfwV+yJKYCUJby5jQ==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-4.13.3.tgz",
+      "integrity": "sha512-zRS1BoBLfIIEaGUY7UiQR5R5jiob+Crr7XwHvk6wHHz4Yg6KNObdBnJrBwXPoaMfEXCMnFIT3mHMwQ8pKeMP0w==",
       "dependencies": {
-        "@strapi/logger": "4.13.2",
-        "@strapi/strapi": "4.13.2",
+        "@strapi/logger": "4.13.3",
+        "@strapi/strapi": "4.13.3",
         "chalk": "4.1.2",
         "fs-extra": "10.0.0",
         "lodash": "4.17.21",
@@ -3002,15 +3002,15 @@
         "npm": ">=6.0.0"
       },
       "peerDependencies": {
-        "@strapi/strapi": "4.12.4"
+        "@strapi/strapi": "^4.13.3"
       }
     },
     "node_modules/@strapi/database": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-4.13.2.tgz",
-      "integrity": "sha512-N8Uqh7jh2guHtEz9GXwJWCjTYXe41sjknKK59MVwHG0P3a85qmKRqGcQr0pWiug+k3O5Ny/GOdVCJKBZE64zig==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-4.13.3.tgz",
+      "integrity": "sha512-/dJjVKo0V/sEqtjaKSJnEZ7VBe3XA4cDRd9IC+YCW6nsxN9CVYrPxdMEL7mW+S1VDOLAqKT56Qzxm6xsB/uVKg==",
       "dependencies": {
-        "@strapi/utils": "4.13.2",
+        "@strapi/utils": "4.13.3",
         "date-fns": "2.30.0",
         "debug": "4.3.4",
         "fs-extra": "10.0.0",
@@ -3052,9 +3052,9 @@
       }
     },
     "node_modules/@strapi/generate-new": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/generate-new/-/generate-new-4.13.2.tgz",
-      "integrity": "sha512-1HgafgHLDMnl2X5Hzqr1h+c9EVVDSAMLscxfjTBdCSgxORM1TDC6zqgLJ90qRu2x9mWOTZET0OSXILI5WbVrOA==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/generate-new/-/generate-new-4.13.3.tgz",
+      "integrity": "sha512-r1+vTb3CPYq4pi41sNVbU6MYOyWmaHKbo7u823H66aXKpg9GU8kN/CTrlXdp3ODfKLJ+qhSi5vJoGcwd7t3IzA==",
       "dependencies": {
         "@sentry/node": "6.19.7",
         "chalk": "^4.1.2",
@@ -3074,13 +3074,13 @@
       }
     },
     "node_modules/@strapi/generators": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-4.13.2.tgz",
-      "integrity": "sha512-dNXmjT68+uK5QqqPh0P+ZegdrII2ClAyjzzbMHnnBYq5Lu1sOJYB894E0h6DCRky7kdWbe38JHjeKo1PISyqfA==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-4.13.3.tgz",
+      "integrity": "sha512-Eoy87jcof+jPPTDmmqFbEVgvCmr/bmUpKynbzxw3lcpc4fuaGeK9SkVJsXiIVSHHZqpHbGywlhjuDYnoSr7GSw==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/typescript-utils": "4.13.2",
-        "@strapi/utils": "4.13.2",
+        "@strapi/typescript-utils": "4.13.3",
+        "@strapi/utils": "4.13.3",
         "chalk": "4.1.2",
         "copyfiles": "2.4.1",
         "fs-extra": "10.0.0",
@@ -3094,9 +3094,9 @@
       }
     },
     "node_modules/@strapi/helper-plugin": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.13.2.tgz",
-      "integrity": "sha512-l1VFAxjVb2kyEG5kto1WAi9g1SAdR4+4GTIAzIVCMFdhaYdo40QUvpnb9Ji5q5N0KCaLi6CTrIjFKBXNme1HtA==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.13.3.tgz",
+      "integrity": "sha512-kKi9nITwYo2SRsQhJ72UDgDWgQeHH1T4h8MjwuAT/5rCnYdXNTxjw147jqHOrFjmnd3xyLyDidTGER7dXi30DQ==",
       "dependencies": {
         "axios": "1.5.0",
         "date-fns": "2.30.0",
@@ -3133,9 +3133,9 @@
       }
     },
     "node_modules/@strapi/logger": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-4.13.2.tgz",
-      "integrity": "sha512-iXcW8rdcrTJPNkLlMXu094wmmSDl1UoCLH0iUnKF6cizzWpHwCm36E/Nq6uCARtYrpVcpog4fl+EWvBvhsAbQw==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-4.13.3.tgz",
+      "integrity": "sha512-4UN5EhY4P/MqBFOZOXPj9kgM/bSg1N5j10uhEm//gS5Oimn4SeWPE9BJ+UcXxcXA5LqSF+LGFn7+gS7fXEM9pA==",
       "dependencies": {
         "lodash": "4.17.21",
         "winston": "3.10.0"
@@ -3146,12 +3146,12 @@
       }
     },
     "node_modules/@strapi/permissions": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-4.13.2.tgz",
-      "integrity": "sha512-2TW8oNgZt56Vnej4w3EgkiZwm7MzRYpu3MZQ6EFLaquZyexv3atelDNxac6dJI6GgA3yYtC+2zkPLxnMcJSHbQ==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-4.13.3.tgz",
+      "integrity": "sha512-skzTWEUp+QQuWu9PaC/BL/DOj6Y4PYXIVPxOnRTKckc+aGZyMldU2kKyId+YZFdeZ7LYm2GvKCuM34uIiOLT/w==",
       "dependencies": {
         "@casl/ability": "5.4.4",
-        "@strapi/utils": "4.13.2",
+        "@strapi/utils": "4.13.3",
         "lodash": "4.17.21",
         "sift": "16.0.1"
       },
@@ -3161,12 +3161,12 @@
       }
     },
     "node_modules/@strapi/plugin-content-manager": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-manager/-/plugin-content-manager-4.13.2.tgz",
-      "integrity": "sha512-dOVcT9nBc15cTYTCtabbCCsi0czjj5q0UUCLtvNEtr2jEUFKK+16ATQWCXZXtiKpaCEwXu21BB8Rt9FUMEUUuQ==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-manager/-/plugin-content-manager-4.13.3.tgz",
+      "integrity": "sha512-0oNAYYmOtjQOxlBD5SvAJX5tYQsniqXeHrLEpQ870rjd4Xa7HRyyt+WJBoBcYGAXnFM8jmahNyUuLjRSuZ4w8g==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/utils": "4.13.2",
+        "@strapi/utils": "4.13.3",
         "lodash": "4.17.21",
         "qs": "6.11.1"
       },
@@ -3176,16 +3176,16 @@
       }
     },
     "node_modules/@strapi/plugin-content-type-builder": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.13.2.tgz",
-      "integrity": "sha512-dPc1Vtz1mjUcrk/gu2Tjz/+DQN0JSyP0IbUl8eRVZoMDV0fvB+rNYUIgPy7x+Kr/x9rc1yugSbEMLvinbvluhA==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.13.3.tgz",
+      "integrity": "sha512-HzAWJJqB+M8dm46dV82bcva1nKmJIfxvfdnENmHO+Gle7BSz2XHDVDteztls7Yn9If4HqVJU9U+CdJ3lUT2LKQ==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
         "@strapi/design-system": "1.9.0",
-        "@strapi/generators": "4.13.2",
-        "@strapi/helper-plugin": "4.13.2",
+        "@strapi/generators": "4.13.3",
+        "@strapi/helper-plugin": "4.13.3",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.13.2",
+        "@strapi/utils": "4.13.3",
         "fs-extra": "10.0.0",
         "immer": "9.0.19",
         "lodash": "4.17.21",
@@ -3211,14 +3211,14 @@
       }
     },
     "node_modules/@strapi/plugin-email": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.13.2.tgz",
-      "integrity": "sha512-bzdhtSRH2kj5pGGI3t5Uf3UwwmaTdT7xdp5gXjESppU0SMpksTCS/vuTl1ED/GZWDnkW6jy+vnX40AvLfp47ew==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.13.3.tgz",
+      "integrity": "sha512-abEOJd3LuuR+z8RlSwCSBCp7ew2ElgcF8yeDR/i5JHfzysGWR53vR8LAAzpi3mDeo6fh2vwf2KkbxAnqm+Em5g==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
         "@strapi/icons": "1.9.0",
-        "@strapi/provider-email-sendmail": "4.13.2",
-        "@strapi/utils": "4.13.2",
+        "@strapi/provider-email-sendmail": "4.13.3",
+        "@strapi/utils": "4.13.3",
         "lodash": "4.17.21",
         "prop-types": "^15.8.1",
         "react-intl": "6.4.1",
@@ -3237,14 +3237,14 @@
       }
     },
     "node_modules/@strapi/plugin-i18n": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-i18n/-/plugin-i18n-4.13.2.tgz",
-      "integrity": "sha512-ZW/53Vc4HFg2VR1aAP8CrMC2WECw6X3tphsVDGdnf6Z7yAvVACVBj3gL8cojfpnGMt4lCQkq/jwkZOR7N4g42A==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-i18n/-/plugin-i18n-4.13.3.tgz",
+      "integrity": "sha512-3gSYYxHkQ4YFti6vbOJPLWDKfOtdbYS6mnwjrIM8rmRMw0hxzYZV8KmChZ2FkpaCUlyWlFS+IMlsTxwXdrF6NQ==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.2",
+        "@strapi/helper-plugin": "4.13.3",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.13.2",
+        "@strapi/utils": "4.13.3",
         "formik": "2.4.0",
         "immer": "9.0.19",
         "lodash": "4.17.21",
@@ -3268,15 +3268,15 @@
       }
     },
     "node_modules/@strapi/plugin-upload": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.13.2.tgz",
-      "integrity": "sha512-19MfRMQHqWiPyGab717RpbwD7XWA+k+LvOLxVriK3qP5zMjuEiFVs7LZ2q8+jAaJdlyXk1iyr3LQQCxFJAvBdw==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.13.3.tgz",
+      "integrity": "sha512-H4/9jzskR1AzgrHbyoIDLqg9nBYrzLE1ok30r6cW+5/6MoPNzjfJBMULks9aZq8NnSaYNTmx6GdIfLvfzF+ovA==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.2",
+        "@strapi/helper-plugin": "4.13.3",
         "@strapi/icons": "1.9.0",
-        "@strapi/provider-upload-local": "4.13.2",
-        "@strapi/utils": "4.13.2",
+        "@strapi/provider-upload-local": "4.13.3",
+        "@strapi/utils": "4.13.3",
         "axios": "1.5.0",
         "byte-size": "7.0.1",
         "cropperjs": "1.6.0",
@@ -3311,14 +3311,14 @@
       }
     },
     "node_modules/@strapi/plugin-users-permissions": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.13.2.tgz",
-      "integrity": "sha512-RnBPMJ9w/3P4k4GlW/KykTqXNrHW2FJbo2/1vAjNX8M9nmiW5zmehZZeE9TIW3JgkQroLAnSkfjRBn97gkxumg==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.13.3.tgz",
+      "integrity": "sha512-+abD48Mxt0kI0nuHTf1rXCvqDPPTBsNgyCblzMsdqXjnpdMXRmbA/3OE03EAJoLe1mNrg//oyV/B1ywhyUVzpg==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.2",
+        "@strapi/helper-plugin": "4.13.3",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.13.2",
+        "@strapi/utils": "4.13.3",
         "bcryptjs": "2.4.3",
         "formik": "2.4.0",
         "grant-koa": "5.4.8",
@@ -3348,9 +3348,9 @@
       }
     },
     "node_modules/@strapi/provider-audit-logs-local": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.13.2.tgz",
-      "integrity": "sha512-jj9KjOo68KCQ9BNbZnvXuPZuR9UPpCk9BYQ9nHLK4k7KmtcclxguuO673fK/bzQJrMT5uVQrWQVGSpCxa7CkvQ==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.13.3.tgz",
+      "integrity": "sha512-vriWcO6a+mN568kvUDF4skNvxwoOfxRW+Dt3PRI3ja+fV90hNMsZInf4/CmglNsyo7n82CNIXq7ZmmOMAAwFuA==",
       "engines": {
         "node": ">=16.0.0 <=20.x.x",
         "npm": ">=6.0.0"
@@ -3360,11 +3360,11 @@
       }
     },
     "node_modules/@strapi/provider-email-sendmail": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.13.2.tgz",
-      "integrity": "sha512-K7bGuF1gD7N8jMhvCtGI6eYskb5aaq+4aLrx+vSWN5zDOgP+bfiGDdX119/ziH82chSO2IyYu/5SmK/8V9hueQ==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.13.3.tgz",
+      "integrity": "sha512-3eg3WDX62dKEgh1yLKft4lMLprwr9OF8bn1n24MVSDy/JdzhfdVUx9fuUTRkPhwOHWX+hVbSx8iJaqF64uuIeQ==",
       "dependencies": {
-        "@strapi/utils": "4.13.2",
+        "@strapi/utils": "4.13.3",
         "sendmail": "^1.6.1"
       },
       "engines": {
@@ -3373,9 +3373,9 @@
       }
     },
     "node_modules/@strapi/provider-upload-aws-s3": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-aws-s3/-/provider-upload-aws-s3-4.13.2.tgz",
-      "integrity": "sha512-VgqbyRCWMg6MTNxhMMv2AYChmPOFjOUTsmCPm3uvPbG+CynuX9+9USBMhfTkfZ06kVuHiOSH4jm2LyantmjXmQ==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-aws-s3/-/provider-upload-aws-s3-4.13.3.tgz",
+      "integrity": "sha512-xhwupP2ath8DS4CjZIbPXv/IkzsT1F4k3PA7hOggVIa6GyPswCceJ0eE/dqREh2ZEA2PbFhH9MCT+4biY9bbLg==",
       "dependencies": {
         "aws-sdk": "2.1437.0",
         "lodash": "4.17.21"
@@ -3386,11 +3386,11 @@
       }
     },
     "node_modules/@strapi/provider-upload-local": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-4.13.2.tgz",
-      "integrity": "sha512-+3vQXNWgblQsP3XRHtktgTFeomo2fpVbM9cJmeN5kDICz+RwuM2yG5zT4e2vqvkLS14BI0M7c4UJz+j7qitP/g==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-4.13.3.tgz",
+      "integrity": "sha512-BrxoSt505GOo6Z1HcpFROreao0kcSP/IHx9NrXqapKLNQEPwN9/G0z5O0Yi5FwS/F3cT4k30T3eCr6giuujkPg==",
       "dependencies": {
-        "@strapi/utils": "4.13.2",
+        "@strapi/utils": "4.13.3",
         "fs-extra": "10.0.0"
       },
       "engines": {
@@ -3399,26 +3399,26 @@
       }
     },
     "node_modules/@strapi/strapi": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-4.13.2.tgz",
-      "integrity": "sha512-pqjLDmiRPcpO0rAt74Z4w4clsKpHGpG0FfHzoTj7HCqzDUdnnNsbAUCekF7681C91jG1Syj40Mqt7fP198X9lw==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-4.13.3.tgz",
+      "integrity": "sha512-n6qBWhsTQbouhZOyc/o23Dw8JlCfJuCYT8HTNc4JLSIyWFD4VqwKGqFKPJ5OnZToa++Le8mUDiiB6VppbG4YUQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@koa/cors": "3.4.3",
         "@koa/router": "10.1.1",
-        "@strapi/admin": "4.13.2",
-        "@strapi/data-transfer": "4.13.2",
-        "@strapi/database": "4.13.2",
-        "@strapi/generate-new": "4.13.2",
-        "@strapi/generators": "4.13.2",
-        "@strapi/logger": "4.13.2",
-        "@strapi/permissions": "4.13.2",
-        "@strapi/plugin-content-manager": "4.13.2",
-        "@strapi/plugin-content-type-builder": "4.13.2",
-        "@strapi/plugin-email": "4.13.2",
-        "@strapi/plugin-upload": "4.13.2",
-        "@strapi/typescript-utils": "4.13.2",
-        "@strapi/utils": "4.13.2",
+        "@strapi/admin": "4.13.3",
+        "@strapi/data-transfer": "4.13.3",
+        "@strapi/database": "4.13.3",
+        "@strapi/generate-new": "4.13.3",
+        "@strapi/generators": "4.13.3",
+        "@strapi/logger": "4.13.3",
+        "@strapi/permissions": "4.13.3",
+        "@strapi/plugin-content-manager": "4.13.3",
+        "@strapi/plugin-content-type-builder": "4.13.3",
+        "@strapi/plugin-email": "4.13.3",
+        "@strapi/plugin-upload": "4.13.3",
+        "@strapi/typescript-utils": "4.13.3",
+        "@strapi/utils": "4.13.3",
         "bcryptjs": "2.4.3",
         "boxen": "5.1.2",
         "chalk": "4.1.2",
@@ -3468,9 +3468,9 @@
       }
     },
     "node_modules/@strapi/typescript-utils": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-4.13.2.tgz",
-      "integrity": "sha512-Rd4NlxfSlMEWVBnXWK+obFNVF71HJp2Z6XA8WnKEtTk/gNHAdkkhmweTgYkC7Qxgy2aOX2Blllyd4A3wpwsWsg==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-4.13.3.tgz",
+      "integrity": "sha512-GYBenXccx9SijfO4DwNHUOywYWJGyCiS/2q17ocGgV837w719CiJy35YgcV3ygj/KGLqPtcqMKEd4J9rPvonrQ==",
       "dependencies": {
         "chalk": "4.1.2",
         "cli-table3": "0.6.2",
@@ -3485,9 +3485,9 @@
       }
     },
     "node_modules/@strapi/ui-primitives": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-1.9.0.tgz",
-      "integrity": "sha512-pjtGALNbWry/rIu50pKpa9K2unoly4FrHwyK1/nbp8OvyMK16E/usPMSndUazQMYv4sjrVczHljNi9Kg5IwQlA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-1.10.0.tgz",
+      "integrity": "sha512-yJ/tRWrnZIQlbyYzHTrpCgbuFfkqUDozbnQcjuak1QsMMk1vpAR729yddusJXngChVn6V4w74GYKvEOXeGhGhQ==",
       "dependencies": {
         "@radix-ui/number": "^1.0.1",
         "@radix-ui/primitive": "^1.0.1",
@@ -3517,9 +3517,9 @@
       }
     },
     "node_modules/@strapi/utils": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-4.13.2.tgz",
-      "integrity": "sha512-f/6RzMP37aaBvyhwyJhVmF8x2e9P0A+nO4tsIgPy8BJ6gIf5rblZHsiTAYnOkPaZkKiBR3i0bxq3lXe1+0c1hA==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-4.13.3.tgz",
+      "integrity": "sha512-+O8JbQ7GOKAI9BJQaZogkx2vlIkgG3qbROG/nWLDxbwSMfyYyHmXYODgYft2Q0MeruBYqAiKJz6Pu9GIGM+reg==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
         "date-fns": "2.30.0",
@@ -3534,9 +3534,9 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3842,9 +3842,9 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.197",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
-      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g=="
+      "version": "4.14.198",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
+      "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg=="
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -5445,9 +5445,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001527",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001527.tgz",
-      "integrity": "sha512-YkJi7RwPgWtXVSgK4lG9AHH57nSzvvOp9MesgXmw4Q7n0C3H04L0foHqfxcmSAm5AcWb8dW9AYj2tR7/5GnddQ==",
+      "version": "1.0.30001528",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001528.tgz",
+      "integrity": "sha512-0Db4yyjR9QMNlsxh+kKWzQtkyflkG/snYheSzkjmvdEtEXB1+jt7A2HmSEiO6XIJPIbo92lHNGNySvE5pZcs5Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -6199,9 +6199,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.32.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.32.1.tgz",
-      "integrity": "sha512-f52QZwkFVDPf7UEQZGHKx6NYxsxmVGJe5DIvbzOdRMJlmT6yv0KDjR8rmy3ngr/t5wU54c7Sp/qIJH0ppbhVpQ==",
+      "version": "3.32.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.32.2.tgz",
+      "integrity": "sha512-Y2rxThOuNywTjnX/PgA5vWM6CZ9QB9sz9oGeCixV8MqXZO70z/5SHzf9EeBrEBK0PN36DnEBBu9O/aGWzKuMZQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -6843,9 +6843,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.508",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.508.tgz",
-      "integrity": "sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg=="
+      "version": "1.4.510",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.510.tgz",
+      "integrity": "sha512-xPfLIPFcN/WLXBpQ/K4UgE98oUBO5Tia6BD4rkSR0wE7ep/PwBVlgvPJQrIBpmJGVAmUzwPKuDbVt9XV6+uC2g=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@strapi/plugin-i18n": "4.13.1",
-    "@strapi/plugin-users-permissions": "4.13.1",
-    "@strapi/provider-upload-aws-s3": "4.13.1",
-    "@strapi/strapi": "4.13.1",
+    "@strapi/plugin-i18n": "4.13.2",
+    "@strapi/plugin-users-permissions": "4.13.2",
+    "@strapi/provider-upload-aws-s3": "4.13.2",
+    "@strapi/strapi": "4.13.2",
     "patch-package": "^8.0.0",
     "pg": "^8.11.3",
     "pluralize": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@strapi/plugin-i18n": "4.12.7",
-    "@strapi/plugin-users-permissions": "4.12.7",
-    "@strapi/provider-upload-aws-s3": "4.12.7",
-    "@strapi/strapi": "4.12.7",
+    "@strapi/plugin-i18n": "4.13.1",
+    "@strapi/plugin-users-permissions": "4.13.1",
+    "@strapi/provider-upload-aws-s3": "4.13.1",
+    "@strapi/strapi": "4.13.1",
     "patch-package": "^8.0.0",
     "pg": "^8.11.3",
     "pluralize": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@strapi/plugin-i18n": "4.13.2",
-    "@strapi/plugin-users-permissions": "4.13.2",
-    "@strapi/provider-upload-aws-s3": "4.13.2",
-    "@strapi/strapi": "4.13.2",
+    "@strapi/plugin-i18n": "4.13.3",
+    "@strapi/plugin-users-permissions": "4.13.3",
+    "@strapi/provider-upload-aws-s3": "4.13.3",
+    "@strapi/strapi": "4.13.3",
     "patch-package": "^8.0.0",
     "pg": "^8.11.3",
     "pluralize": "^8.0.0",


### PR DESCRIPTION
This includes a slightly bigger breaking change that we should test locally:
https://github.com/strapi/strapi/releases/tag/v4.13.1
