### PR TITLE
feat: runtime-editable string collections

### DIFF
--- a/src/api/translation/content-types/translation/schema.json
+++ b/src/api/translation/content-types/translation/schema.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": true
+    "draftAndPublish": false
   },
   "pluginOptions": {
     "i18n": {
@@ -16,7 +16,7 @@
     }
   },
   "attributes": {
-    "Field": {
+    "field": {
       "displayName": "Field",
       "type": "component",
       "repeatable": true,
@@ -27,7 +27,7 @@
       },
       "component": "field.field"
     },
-    "Groupname": {
+    "scope": {
       "pluginOptions": {
         "i18n": {
           "localized": false

--- a/src/api/translation/content-types/translation/schema.json
+++ b/src/api/translation/content-types/translation/schema.json
@@ -1,0 +1,41 @@
+{
+  "kind": "collectionType",
+  "collectionName": "translations",
+  "info": {
+    "singularName": "translation",
+    "pluralName": "translations",
+    "displayName": "Translations",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "Field": {
+      "displayName": "Field",
+      "type": "component",
+      "repeatable": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "field.field"
+    },
+    "Groupname": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string",
+      "required": true,
+      "unique": true
+    }
+  }
+}

--- a/src/api/translation/content-types/translation/schema.json
+++ b/src/api/translation/content-types/translation/schema.json
@@ -30,12 +30,12 @@
     "Groupname": {
       "pluginOptions": {
         "i18n": {
-          "localized": true
+          "localized": false
         }
       },
       "type": "string",
       "required": true,
-      "unique": true
+      "unique": false
     }
   }
 }

--- a/src/api/translation/controllers/translation.js
+++ b/src/api/translation/controllers/translation.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * translation controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::translation.translation');

--- a/src/api/translation/routes/translation.js
+++ b/src/api/translation/routes/translation.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * translation router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::translation.translation');

--- a/src/api/translation/services/translation.js
+++ b/src/api/translation/services/translation.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * translation service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::translation.translation');

--- a/src/components/field/field.json
+++ b/src/components/field/field.json
@@ -13,7 +13,7 @@
       "unique": false
     },
     "Value": {
-      "type": "string",
+      "type": "text",
       "required": false
     }
   }

--- a/src/components/field/field.json
+++ b/src/components/field/field.json
@@ -7,12 +7,12 @@
   },
   "options": {},
   "attributes": {
-    "Name": {
+    "name": {
       "type": "string",
       "required": true,
       "unique": false
     },
-    "Value": {
+    "value": {
       "type": "text",
       "required": false
     }

--- a/src/components/field/field.json
+++ b/src/components/field/field.json
@@ -14,7 +14,7 @@
     },
     "value": {
       "type": "text",
-      "required": false
+      "required": true
     }
   }
 }

--- a/src/components/field/field.json
+++ b/src/components/field/field.json
@@ -1,0 +1,20 @@
+{
+  "collectionName": "components_field_fields",
+  "info": {
+    "displayName": "Field",
+    "icon": "alien",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "Name": {
+      "type": "string",
+      "required": true,
+      "unique": false
+    },
+    "Value": {
+      "type": "string",
+      "required": false
+    }
+  }
+}

--- a/src/components/field/field.json
+++ b/src/components/field/field.json
@@ -2,7 +2,7 @@
   "collectionName": "components_field_fields",
   "info": {
     "displayName": "Field",
-    "icon": "alien",
+    "icon": "",
     "description": ""
   },
   "options": {},


### PR DESCRIPTION
@joschka this is what we looked at last Friday.

The idea is to replace our hard-coded Singletypes that effectively just represent string lookup (like `AmtsgerichtCommon` and the contained fields such as `featureName`)

This instead would add a CollectionType (prototype name `Translations`, up for discussion), which allows dynamic editing of translation groups and containing fields.

pros:
- Adding / editing translation groups & variables at runtime without re-deploy
- No more typing of each variable in the App
- Explicit lookup and fallback (if a variable wasn't found we could still show `Amtsgericht.featureName`)

cons:
- Less type safety (we can't "know" that `Amtsgericht.featureName` exists via zod validation)
- Potential of accidental deletion/editing
