### PR TITLE
chore: Internal GitHub Action migration

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -111,7 +111,7 @@ jobs:
     environment: staging
     steps:
       - name: Deploy new staging image
-        uses: digitalservicebund/github-actions/argocd-deploy@a223a68bc5982e5175beb73c708d99d8f9ba7858
+        uses: digitalservicebund/argocd-deploy@4fac1bb67c92ed168f6d9b22f8779ce241a9e412 # v1.0.0
         with:
           environment: staging
           version: ${{ github.sha }}
@@ -123,7 +123,7 @@ jobs:
           argocd_server: ${{ secrets.ARGOCD_SERVER }}
           argocd_sync_timeout: 300
       - name: Report Deployment
-        uses: digitalservicebund/github-actions/track-deployment@34a48d29a9c4cc2fd6710b8eb37e13618a08fa88
+        uses: digitalservicebund/track-deployment@5a2815e150e1268983aac5ca04c8c046ed1b614a # v1.0.0
         with:
           project: a2j-rechtsantragstelle
           environment: staging


### PR DESCRIPTION
As mentioned [here](https://digitalservicebund.slack.com/archives/C03M9TZTDK8/p1710341286056739), we have to split our internal GitHub actions repo. This PR update your CI configuration to point to the new repositories. Please, review and merge this PR. Don't hesitate to contact the Platform team if you run into any issue.