### PR TITLE
fix(remove "required" constraint from relational fields)

### DIFF
--- a/src/components/form-elements/select.json
+++ b/src/components/form-elements/select.json
@@ -25,8 +25,7 @@
     "errors": {
       "type": "relation",
       "relation": "oneToMany",
-      "target": "api::error.error",
-      "required": true
+      "target": "api::error.error"
     }
   }
 }

--- a/src/components/form-elements/tile-group.json
+++ b/src/components/form-elements/tile-group.json
@@ -24,8 +24,7 @@
     "errors": {
       "type": "relation",
       "relation": "oneToMany",
-      "target": "api::error.error",
-      "required": true
+      "target": "api::error.error"
     },
     "useTwoColumns": {
       "type": "boolean",

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -1,99 +1,5 @@
 import type { Schema, Attribute } from '@strapi/strapi';
 
-export interface MetaContainer extends Schema.Component {
-  collectionName: 'components_meta_containers';
-  info: {
-    displayName: 'Container';
-    description: '';
-  };
-  attributes: {
-    backgroundColor: Attribute.Enumeration<
-      ['default', 'white', 'blue', 'yellow']
-    > &
-      Attribute.Required &
-      Attribute.DefaultTo<'default'>;
-    paddingTop: Attribute.Enumeration<
-      [
-        'default',
-        'px0',
-        'px8',
-        'px16',
-        'px24',
-        'px32',
-        'px40',
-        'px48',
-        'px56',
-        'px64'
-      ]
-    > &
-      Attribute.Required &
-      Attribute.DefaultTo<'default'>;
-    paddingBottom: Attribute.Enumeration<
-      [
-        'default',
-        'px0',
-        'px8',
-        'px16',
-        'px24',
-        'px32',
-        'px40',
-        'px48',
-        'px56',
-        'px64'
-      ]
-    > &
-      Attribute.Required &
-      Attribute.DefaultTo<'default'>;
-  };
-}
-
-export interface MetaBackground extends Schema.Component {
-  collectionName: 'components_meta_backgrounds';
-  info: {
-    displayName: 'Outer Background';
-    description: '';
-  };
-  attributes: {
-    backgroundColor: Attribute.Enumeration<
-      ['default', 'white', 'blue', 'darkBlue', 'yellow']
-    > &
-      Attribute.Required &
-      Attribute.DefaultTo<'default'>;
-    paddingTop: Attribute.Enumeration<
-      [
-        'default',
-        'px0',
-        'px8',
-        'px16',
-        'px24',
-        'px32',
-        'px40',
-        'px48',
-        'px56',
-        'px64'
-      ]
-    > &
-      Attribute.Required &
-      Attribute.DefaultTo<'default'>;
-    paddingBottom: Attribute.Enumeration<
-      [
-        'default',
-        'px0',
-        'px8',
-        'px16',
-        'px24',
-        'px32',
-        'px40',
-        'px48',
-        'px56',
-        'px64'
-      ]
-    > &
-      Attribute.Required &
-      Attribute.DefaultTo<'default'>;
-  };
-}
-
 export interface PageVideo extends Schema.Component {
   collectionName: 'components_page_videos';
   info: {
@@ -324,6 +230,100 @@ export interface PageArraySummary extends Schema.Component {
   };
 }
 
+export interface MetaContainer extends Schema.Component {
+  collectionName: 'components_meta_containers';
+  info: {
+    displayName: 'Container';
+    description: '';
+  };
+  attributes: {
+    backgroundColor: Attribute.Enumeration<
+      ['default', 'white', 'blue', 'yellow']
+    > &
+      Attribute.Required &
+      Attribute.DefaultTo<'default'>;
+    paddingTop: Attribute.Enumeration<
+      [
+        'default',
+        'px0',
+        'px8',
+        'px16',
+        'px24',
+        'px32',
+        'px40',
+        'px48',
+        'px56',
+        'px64'
+      ]
+    > &
+      Attribute.Required &
+      Attribute.DefaultTo<'default'>;
+    paddingBottom: Attribute.Enumeration<
+      [
+        'default',
+        'px0',
+        'px8',
+        'px16',
+        'px24',
+        'px32',
+        'px40',
+        'px48',
+        'px56',
+        'px64'
+      ]
+    > &
+      Attribute.Required &
+      Attribute.DefaultTo<'default'>;
+  };
+}
+
+export interface MetaBackground extends Schema.Component {
+  collectionName: 'components_meta_backgrounds';
+  info: {
+    displayName: 'Outer Background';
+    description: '';
+  };
+  attributes: {
+    backgroundColor: Attribute.Enumeration<
+      ['default', 'white', 'blue', 'darkBlue', 'yellow']
+    > &
+      Attribute.Required &
+      Attribute.DefaultTo<'default'>;
+    paddingTop: Attribute.Enumeration<
+      [
+        'default',
+        'px0',
+        'px8',
+        'px16',
+        'px24',
+        'px32',
+        'px40',
+        'px48',
+        'px56',
+        'px64'
+      ]
+    > &
+      Attribute.Required &
+      Attribute.DefaultTo<'default'>;
+    paddingBottom: Attribute.Enumeration<
+      [
+        'default',
+        'px0',
+        'px8',
+        'px16',
+        'px24',
+        'px32',
+        'px40',
+        'px48',
+        'px56',
+        'px64'
+      ]
+    > &
+      Attribute.Required &
+      Attribute.DefaultTo<'default'>;
+  };
+}
+
 export interface FormHelperTile extends Schema.Component {
   collectionName: 'components_basic_tile';
   info: {
@@ -363,19 +363,6 @@ export interface FormHelperErrors extends Schema.Component {
   };
 }
 
-export interface FieldField extends Schema.Component {
-  collectionName: 'components_field_fields';
-  info: {
-    displayName: 'Field';
-    icon: '';
-    description: '';
-  };
-  attributes: {
-    name: Attribute.String & Attribute.Required;
-    value: Attribute.Text & Attribute.Required;
-  };
-}
-
 export interface FormElementsTimeInput extends Schema.Component {
   collectionName: 'components_form_elements_time_inputs';
   info: {
@@ -409,8 +396,7 @@ export interface FormElementsTileGroup extends Schema.Component {
       'form-elements.tile-group',
       'oneToMany',
       'api::error.error'
-    > &
-      Attribute.Required;
+    >;
     useTwoColumns: Attribute.Boolean &
       Attribute.Required &
       Attribute.DefaultTo<true>;
@@ -451,8 +437,7 @@ export interface FormElementsSelect extends Schema.Component {
       'form-elements.select',
       'oneToMany',
       'api::error.error'
-    > &
-      Attribute.Required;
+    >;
   };
 }
 
@@ -626,6 +611,19 @@ export interface FormElementsAutoSuggestInput extends Schema.Component {
   };
 }
 
+export interface FieldField extends Schema.Component {
+  collectionName: 'components_field_fields';
+  info: {
+    displayName: 'Field';
+    icon: '';
+    description: '';
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    value: Attribute.Text & Attribute.Required;
+  };
+}
+
 export interface BasicParagraph extends Schema.Component {
   collectionName: 'components_basic_paragraphs';
   info: {
@@ -689,8 +687,6 @@ export interface BasicHeading extends Schema.Component {
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
-      'meta.container': MetaContainer;
-      'meta.background': MetaBackground;
       'page.video': PageVideo;
       'page.user-feedback': PageUserFeedback;
       'page.navigation-item': PageNavigationItem;
@@ -706,10 +702,11 @@ declare module '@strapi/types' {
       'page.box': PageBox;
       'page.box-with-image': PageBoxWithImage;
       'page.array-summary': PageArraySummary;
+      'meta.container': MetaContainer;
+      'meta.background': MetaBackground;
       'form-helper.tile': FormHelperTile;
       'form-helper.select-option': FormHelperSelectOption;
       'form-helper.errors': FormHelperErrors;
-      'field.field': FieldField;
       'form-elements.time-input': FormElementsTimeInput;
       'form-elements.tile-group': FormElementsTileGroup;
       'form-elements.textarea': FormElementsTextarea;
@@ -722,6 +719,7 @@ declare module '@strapi/types' {
       'form-elements.checkbox': FormElementsCheckbox;
       'form-elements.button': FormElementsButton;
       'form-elements.auto-suggest-input': FormElementsAutoSuggestInput;
+      'field.field': FieldField;
       'basic.paragraph': BasicParagraph;
       'basic.link': BasicLink;
       'basic.heading': BasicHeading;


### PR DESCRIPTION
This PR removes "required": true from the errors array of strapi components, as this feature is NOT supported by Strapi and leads to bugs, like the white-screen duplication bug.

See the following for explanations/more info:
https://github.com/strapi/strapi/pull/20557
https://github.com/strapi/strapi/issues/19976
https://feedback.strapi.io/customization/p/specify-relation-column-as-required
