### PR TITLE
feat/add-new-possible-color-to-result-page: add default to pageType enum

### DIFF
--- a/src/api/result-page/content-types/result-page/schema.json
+++ b/src/api/result-page/content-types/result-page/schema.json
@@ -80,7 +80,8 @@
       "enum": [
         "error",
         "success",
-        "warning"
+        "warning",
+        "default"
       ],
       "required": true,
       "default": "error"

--- a/src/api/result-page/content-types/result-page/schema.json
+++ b/src/api/result-page/content-types/result-page/schema.json
@@ -81,7 +81,7 @@
         "error",
         "success",
         "warning",
-        "default"
+        "info"
       ],
       "required": true,
       "default": "error"

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -360,19 +360,6 @@ export interface FormHelperErrors extends Schema.Component {
   };
 }
 
-export interface FieldField extends Schema.Component {
-  collectionName: 'components_field_fields';
-  info: {
-    displayName: 'Field';
-    icon: '';
-    description: '';
-  };
-  attributes: {
-    name: Attribute.String & Attribute.Required;
-    value: Attribute.Text & Attribute.Required;
-  };
-}
-
 export interface FormElementsTimeInput extends Schema.Component {
   collectionName: 'components_form_elements_time_inputs';
   info: {
@@ -623,6 +610,19 @@ export interface FormElementsAutoSuggestInput extends Schema.Component {
   };
 }
 
+export interface FieldField extends Schema.Component {
+  collectionName: 'components_field_fields';
+  info: {
+    displayName: 'Field';
+    icon: '';
+    description: '';
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    value: Attribute.Text & Attribute.Required;
+  };
+}
+
 export interface BasicParagraph extends Schema.Component {
   collectionName: 'components_basic_paragraphs';
   info: {
@@ -706,7 +706,6 @@ declare module '@strapi/types' {
       'form-helper.tile': FormHelperTile;
       'form-helper.select-option': FormHelperSelectOption;
       'form-helper.errors': FormHelperErrors;
-      'field.field': FieldField;
       'form-elements.time-input': FormElementsTimeInput;
       'form-elements.tile-group': FormElementsTileGroup;
       'form-elements.textarea': FormElementsTextarea;
@@ -719,6 +718,7 @@ declare module '@strapi/types' {
       'form-elements.checkbox': FormElementsCheckbox;
       'form-elements.button': FormElementsButton;
       'form-elements.auto-suggest-input': FormElementsAutoSuggestInput;
+      'field.field': FieldField;
       'basic.paragraph': BasicParagraph;
       'basic.link': BasicLink;
       'basic.heading': BasicHeading;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1380,9 +1380,7 @@ export interface ApiResultPageResultPage extends Schema.CollectionType {
           localized: true;
         };
       }>;
-    pageType: Attribute.Enumeration<
-      ['error', 'success', 'warning', 'default']
-    > &
+    pageType: Attribute.Enumeration<['error', 'success', 'warning', 'info']> &
       Attribute.Required &
       Attribute.SetPluginOptions<{
         i18n: {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1380,7 +1380,9 @@ export interface ApiResultPageResultPage extends Schema.CollectionType {
           localized: true;
         };
       }>;
-    pageType: Attribute.Enumeration<['error', 'success', 'warning']> &
+    pageType: Attribute.Enumeration<
+      ['error', 'success', 'warning', 'default']
+    > &
       Attribute.Required &
       Attribute.SetPluginOptions<{
         i18n: {


### PR DESCRIPTION
Implementation of the first part of the following ticket: https://app.asana.com/0/1207022303033556/1208516793579262/f

- added "default" to enum on result page (necessary for new result page "erfolg/per-post-klagen" 