### PR TITLE
refactor(BoxWithImage variants)

### DIFF
--- a/database/migrations/2024.12.27T00.00.00.box-with-image-size-variants.js
+++ b/database/migrations/2024.12.27T00.00.00.box-with-image-size-variants.js
@@ -1,0 +1,20 @@
+"use strict";
+
+/**
+ * what this migration is doing:
+   Switches existing "ImgMTextL" variant BoxWithImage instances to their new equivalents
+ */
+
+async function up(knex) {
+  try {
+    const result = await knex("components_page_box_with_images").whereNotNull('variant').update({
+    variant: 'M'
+    });
+    console.log(`Updated ${result.length} row(s)`);
+  } catch (error) {
+    console.log("error occured during migration. Skipping migration");
+    console.log(error);
+  }
+}
+
+module.exports = { up };

--- a/src/components/page/box-with-image.json
+++ b/src/components/page/box-with-image.json
@@ -42,7 +42,12 @@
     "variant": {
       "type": "enumeration",
       "enum": [
-        "ImgMTextL"
+        "XS",
+        "S",
+        "M",
+        "L",
+        "XL",
+        "XXL"
       ]
     }
   }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -476,7 +476,7 @@ export interface PageBoxWithImage extends Struct.ComponentSchema {
     image: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
       Schema.Attribute.Required;
     outerBackground: Schema.Attribute.Component<'meta.background', false>;
-    variant: Schema.Attribute.Enumeration<['ImgMTextL']>;
+    variant: Schema.Attribute.Enumeration<['XS', 'S', 'M', 'L', 'XL', 'XXL']>;
   };
 }
 


### PR DESCRIPTION
This PR adds additional size variants to the Strapi BoxWithImage component.

It also runs a database migration to update all out-of-date instances of ImgMTextL to 'M'
