### PR TITLE
feat(List): add variant

### DIFF
--- a/database/migrations/2025.03.14T00.00.00.list-fill-variant-from-isNumeric.js
+++ b/database/migrations/2025.03.14T00.00.00.list-fill-variant-from-isNumeric.js
@@ -1,0 +1,31 @@
+"use strict";
+
+/**
+ * The List component currently has a boolean field `isNumeric`.
+ * We want to instead move to an enum field `variant` = `unordered` / `numbered` (to be extended later).
+ * This migration fills the new `variant` field for all List components based on the value of `isNumeric`
+ */
+
+async function up(knex) {
+  try {
+    const lists = knex("components_page_lists");
+    const listsWithVariantNull = lists.where({ variant: null });
+
+    const changesNumbered = await listsWithVariantNull
+      .where({ is_numeric: true })
+      .update({ variant: "numbered" });
+
+    const changesUnordered = await listsWithVariantNull
+      .where({ is_numeric: false })
+      .update({ variant: "unordered" });
+
+    console.log(
+      `Updated ${changesNumbered} lists to numbered and ${changesUnordered} lists to ordered`,
+    );
+  } catch (error) {
+    console.error(error);
+    console.warn("Error occurred during migration. Skipping...");
+  }
+}
+
+module.exports = { up };

--- a/src/components/page/list.json
+++ b/src/components/page/list.json
@@ -37,6 +37,15 @@
       "type": "component",
       "repeatable": false,
       "component": "meta.background"
+    },
+    "variant": {
+      "type": "enumeration",
+      "enum": [
+        "unordered",
+        "numbered"
+      ],
+      "default": "unordered",
+      "required": true
     }
   }
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -600,6 +600,9 @@ export interface PageList extends Struct.ComponentSchema {
     items: Schema.Attribute.Component<'page.list-item', true>;
     outerBackground: Schema.Attribute.Component<'meta.background', false>;
     subheading: Schema.Attribute.RichText;
+    variant: Schema.Attribute.Enumeration<['unordered', 'numbered']> &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<'unordered'>;
   };
 }
 


### PR DESCRIPTION
- adds new required `variant` field to `List`
- adds migration that fills `variant` from `is_numeric`

Note: Because migrations are executed BEFORE schema changes, I plan to cherry-pick the commits to main one-by-one