### PR TITLE
Set the db repository to check vulnerabilities

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Generate cosign vulnerability scan record
         uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           image-ref: ${{ env.IMAGE_NAME }}:${{ github.sha }}
           format: "cosign-vuln"
@@ -74,6 +76,8 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           image-ref: "${{ env.IMAGE_NAME }}:${{ github.sha }}"
           format: "template"


### PR DESCRIPTION
### Changes

- Set the DB repository to check vulnerabilities instead of download every check. It might improve the performance during the deployment.