### PR TITLE
feat(Tile): description as string

### DIFF
--- a/src/components/form-helper/tile.json
+++ b/src/components/form-helper/tile.json
@@ -11,7 +11,7 @@
       "required": true
     },
     "description": {
-      "type": "richtext"
+      "type": "string"
     },
     "value": {
       "type": "string",


### PR DESCRIPTION
- makes Tile description text only (only changes display in UI, not the content itself)