### PR TITLE
Potential fix for code scanning alert no. 65: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -109,6 +109,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: staging
+    permissions:
+      contents: read
     steps:
       - name: Deploy new staging image
         uses: digitalservicebund/argocd-deploy@4fac1bb67c92ed168f6d9b22f8779ce241a9e412 # v1.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/a2j-rechtsantragstelle-strapi/security/code-scanning/65](https://github.com/digitalservicebund/a2j-rechtsantragstelle-strapi/security/code-scanning/65)

To fix the issue, we need to add a `permissions` block to the `deploy-staging` job in the workflow file. This block should specify the minimal permissions required for the job to function correctly. Based on the job's steps, it does not seem to require write access to any GitHub resources, so we can set `contents: read` as the minimal permission.

The changes will be made in the `.github/workflows/ci-pipeline.yml` file, specifically within the `deploy-staging` job definition. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
