### PR TITLE
rename env vars for strapi transfer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,6 @@ API_TOKEN_SALT=jvdnndiwppccgrplclknsrgsvmevcfpqidywnaqnniacbcrsovsqohyyqnouagib
 APP_KEYS="toBeModified1,toBeModified2"
 STRAPI_TRANSFER_TOKEN=REPLACEME
 STRAPI_TRANSFER_URL=https://REPLACEME/admin
-TRANSFER_TOKEN_LOCAL=REPLACEME
 
 # Uploads to OTC Object Storage Service (OBS)
 # leave empty in local development!

--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,9 @@ ADMIN_JWT_SECRET=6YfHrcOhoJR9P/AUFpUMWw==
 JWT_SECRET=7Q+xaEnWZA1hikIx9e/fFg==
 API_TOKEN_SALT=jvdnndiwppccgrplclknsrgsvmevcfpqidywnaqnniacbcrsovsqohyyqnouagib
 APP_KEYS="toBeModified1,toBeModified2"
-TRANSFER_TOKEN_REMOTE=REPLACEME
+STRAPI_TRANSFER_TOKEN=REPLACEME
+STRAPI_TRANSFER_URL=https://REPLACEME/admin
 TRANSFER_TOKEN_LOCAL=REPLACEME
-TRANSFER_URL_REMOTE=https://REPLACEME/admin
 
 # Uploads to OTC Object Storage Service (OBS)
 # leave empty in local development!

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Replaces all local data with a copy of remote instance
 ### Steps
 
 1. Create a `Push` transfer token in your local instance ([Settings / Transfer Tokens](http://localhost:1337/admin/settings/transfer-tokens)) & save as `TRANSFER_TOKEN_LOCAL` into your local `.env` file
-2. Create a `Pull` transfer token on the [remote instance](https://a2j-rast-strapi.dev.ds4g.net/admin/settings/transfer-tokens) and save as `TRANSFER_TOKEN_REMOTE` into your `.env` file
-3. Update the `TRANSFER_URL_REMOTE` (Note: this should point to the `/admin` endpoint)
+2. Create a `Pull` transfer token on the [remote instance](https://a2j-rast-strapi.dev.ds4g.net/admin/settings/transfer-tokens) and save as `STRAPI_TRANSFER_TOKEN` into your `.env` file
+3. Update the `STRAPI_TRANSFER_URL` (Note: this should point to the `/admin` endpoint)
 4. Run `npm run transfer`. If the asset transfer process hangs, cancel it and retry with: `npm run transfer -- --exclude files`
 
 ## Data migrations

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Replaces all local data with a copy of remote instance
 
 1. Create a `Pull` transfer token on the [remote instance](https://a2j-rast-strapi.dev.ds4g.net/admin/settings/transfer-tokens) and save as `STRAPI_TRANSFER_TOKEN` into your `.env` file
 2. Update the `STRAPI_TRANSFER_URL` (Note: this should point to the `/admin` endpoint)
-3. Run `npm run transfer`. If the asset transfer process hangs, cancel it and retry with: `npm run transfer -- --exclude files`
+3. Run `npm run transfer`
 4. Choose the option: `Pull data from remote Strapi to local`
 
 ## Data migrations

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Replaces all local data with a copy of remote instance
 
 ### Steps
 
-1. Create a `Push` transfer token in your local instance ([Settings / Transfer Tokens](http://localhost:1337/admin/settings/transfer-tokens)) & save as `TRANSFER_TOKEN_LOCAL` into your local `.env` file
-2. Create a `Pull` transfer token on the [remote instance](https://a2j-rast-strapi.dev.ds4g.net/admin/settings/transfer-tokens) and save as `STRAPI_TRANSFER_TOKEN` into your `.env` file
-3. Update the `STRAPI_TRANSFER_URL` (Note: this should point to the `/admin` endpoint)
-4. Run `npm run transfer`. If the asset transfer process hangs, cancel it and retry with: `npm run transfer -- --exclude files`
+1. Create a `Pull` transfer token on the [remote instance](https://a2j-rast-strapi.dev.ds4g.net/admin/settings/transfer-tokens) and save as `STRAPI_TRANSFER_TOKEN` into your `.env` file
+2. Update the `STRAPI_TRANSFER_URL` (Note: this should point to the `/admin` endpoint)
+3. Run `npm run transfer`. If the asset transfer process hangs, cancel it and retry with: `npm run transfer -- --exclude files`
+4. Choose the option: `Pull data from remote Strapi to local`
 
 ## Data migrations
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "strapi start",
     "strapi": "strapi",
     "test": "jest --forceExit --detectOpenHandles",
-    "transfer": "source .env && strapi transfer --from $TRANSFER_URL_REMOTE --from-token $TRANSFER_TOKEN_REMOTE --to-token $TRANSFER_TOKEN_LOCAL",
+    "transfer": "source .env && strapi transfer",
     "plugin:build": "npm run build --workspace plugins/strapi-plugin-gh-workflow-trigger-v5",
     "plugin:develop": "npm run watch --workspace plugins/strapi-plugin-gh-workflow-trigger-v5"
   },


### PR DESCRIPTION
The strapi cli for transfers has [changed](https://github.com/strapi/strapi/pull/23421) therefore adaptions were necessary. 
- error with current state: `Only one remote source (from) or destination (to) option may be provided.` 

command works when to-token is removed (source .env && strapi transfer --from $TRANSFER_URL_REMOTE --from-token $TRANSFER_TOKEN_REMOTE) but then one is still asked to specify STRAPI_TRANSFER_URL and STRAPI_TRANSFER_TOKEN. Therefore the names in the env file were adapted

With the changes the local push token became obsolete and I removed it from the Readme